### PR TITLE
Fixed: Mod2. Retain panel cursor pos after FS mods #322 #73

### DIFF
--- a/src/panel.cpp
+++ b/src/panel.cpp
@@ -1831,14 +1831,14 @@ void PanelWin::OperThreadStopped()
 				foundCurrent = true;
 			}
 		}
-		// in no-sort the best is to stay at the same custor location
+		// in no-sort mode the best is to stay at the same cursor location
 		if (!foundCurrent && _list.SortMode() == SORT_NONE)
 		{
 			SetCurrent(_operCursorLoc);
 			foundCurrent = true;
 		}
 
-		// try closest node in current sort mode
+		// in sorted mode try closest node using current sort mode
 		if (!foundCurrent && !_operCurrent.name.IsEmpty())
 		{
 			int n = _list.FindExactOrClosestSucceeding( _operCurrent, HideDotsInDir() );

--- a/src/vfs.cpp
+++ b/src/vfs.cpp
@@ -1639,7 +1639,7 @@ static int _BSearch(FSNode& n, const std::vector<FSNode*>& nodeVector, int(*CmpF
 	int iRight = vsize-1;
 	int cmp = CmpFunc(&n, nodeVector[iLeft]);
 
-	for (int i = iRight / 2; iLeft< iRight ; i = (iLeft + iRight) / 2)
+	for (int i = iRight / 2; iLeft <= iRight ; i = (iLeft + iRight) / 2)
 	{
 		int cmp = CmpFunc(&n, nodeVector[i]);
 		if (cmp == 0) // found exact match
@@ -1678,8 +1678,8 @@ int CmpFunc(FSNode* a, FSNode* b)
 								int cmpExt = a->CmpByExt(*b, isCaseSensitive);
 								if (cmpExt)
 									return isAscending ? cmpExt : -cmpExt;
-	} // if not, do name comparison in the current ascending mode
-	  // i.e. fall into next case
+	} // if extensions match, do name comparison using current ascending mode
+	  // i.e. fall into the next case
 	case SORT_NAME:
 	{
 								int cmpName = isCaseSensitive ? a->name.Cmp(b->name) : a->name.CmpNoCase(b->name);
@@ -1702,10 +1702,9 @@ int CmpFunc(FSNode* a, FSNode* b)
 	default:
 		return 0;
 	}
-	// if ext|size|mtime are the same, return name comparison in ascending=true mode
+	// if size|mtime match, return name comparison in ascending=true mode
 	return  isCaseSensitive ? a->name.Cmp(b->name) : a->name.CmpNoCase(b->name);
 }
-
 
 FSNodeCmpFunc* FSNodeVectorSorter::getCmpFunc(bool isAscending, bool isCaseSensitive, SORT_MODE sortMode)
 {

--- a/src/wal/wal.cpp
+++ b/src/wal/wal.cpp
@@ -126,6 +126,31 @@ namespace wal
 		return false;
 	}
 
+	// not null-safe like strcmp
+	int unicode_strcmp(const unicode_t* s1, const unicode_t* s2)
+	{
+		for (; *s1 == *s2; s1++, s2++)
+		{
+			if (*s1 == 0)
+				return 0;
+		}
+		return *s1 > *s2 ? 1 : -1;
+	}
+
+	// not null-safe, like stricmp
+	int unicode_stricmp(const unicode_t* s1, const unicode_t* s2)
+	{
+		for (;; s1++, s2++)
+		{
+			unicode_t c1 = UnicodeLC(*s1);
+			unicode_t c2 = UnicodeLC(*s1);
+			if (c1 != c2)
+				return c1 > c2 ? 1 : -1;
+			if (c1 == 0)
+				return 0;
+		}
+	}
+
 	bool unicode_starts_with_and_not_equal( const unicode_t* Str, const unicode_t* SubStr )
 	{
 		if ( !Str || !SubStr ) { return false; }

--- a/src/wal/wal.cpp
+++ b/src/wal/wal.cpp
@@ -143,7 +143,7 @@ namespace wal
 		for (;; s1++, s2++)
 		{
 			unicode_t c1 = UnicodeLC(*s1);
-			unicode_t c2 = UnicodeLC(*s1);
+			unicode_t c2 = UnicodeLC(*s2);
 			if (c1 != c2)
 				return c1 > c2 ? 1 : -1;
 			if (c1 == 0)

--- a/src/wal/wal.h
+++ b/src/wal/wal.h
@@ -39,6 +39,8 @@ namespace wal
 	std::vector<char> unicode_to_utf8( const unicode_t* u );
 
 	bool unicode_is_equal( const unicode_t* Str, const unicode_t* SubStr );
+	int unicode_strcmp(const unicode_t* s1, const unicode_t* s2);
+	int unicode_stricmp(const unicode_t* s1, const unicode_t* s2);
 	bool unicode_starts_with_and_not_equal( const unicode_t* Str, const unicode_t* SubStr );
 
 ///////////////////  Exceptions ///////////////////////////////////////////////


### PR DESCRIPTION
This closes the last failing test case that is stated in #326: retaining cursor position after Shift-F6 rename.

Note that wal.cpp now has unicode_strcmp/unicode_stricmp functions. viktor-podzigun may consider to use these.