### PR TITLE
Fix: #346 Windows. Pressing Alt-key freezes Ctrl|Shoft switchings of the...

### DIFF
--- a/src/swl/swl_wincoreMS.cpp
+++ b/src/swl/swl_wincoreMS.cpp
@@ -410,6 +410,12 @@ namespace wal
 					cevent_move cevm( cpoint ( lParam & 0xFFFF, ( lParam >> 16 ) & 0xFFFF ) );
 					return win->Event( &cevm );
 				}
+				case WM_SYSCOMMAND:
+				{
+					// without this pressing Alt-key freezes Ctrl|Shift switchings of the bottombar until Alt is pressed for the second time
+					if (wParam == SC_KEYMENU && (lParam >> 16) <= 0) 
+						return 0;
+				}
 
 			};
 


### PR DESCRIPTION
... bottombar