### PR TITLE
Fixed: #372 Shortcut conflict in Files menu 

### DIFF
--- a/install-files/share/wcm/lang/ltext.ru
+++ b/install-files/share/wcm/lang/ltext.ru
@@ -1,5 +1,5 @@
 #ncwin.cpp:610
-id "Apply &command"
+id "A&pply command"
 txt "Применить команду"
 
 #ncwin.cpp:609

--- a/src/ncwin.cpp
+++ b/src/ncwin.cpp
@@ -608,7 +608,7 @@ NCWin::NCWin()
 	_mdFiles.AddCmd( ID_DELETE, _LT( "&Delete" ), "F8" );
 	_mdFiles.AddSplit();
 	_mdFiles.AddCmd( ID_FILE_ATTRIBUTES, _LT( "File &attributes" ), "Ctrl-A" );
-	_mdFiles.AddCmd( ID_APPLY_COMMAND, _LT( "Apply &command" ), "Ctrl-G" );
+	_mdFiles.AddCmd( ID_APPLY_COMMAND, _LT( "A&pply command" ), "Ctrl-G" );
 
 	_mdFiles.AddSplit();
 	_mdFiles.AddCmd( ID_GROUP_SELECT, _LT( "Select &group" ), "Gray +" );


### PR DESCRIPTION
I have no idea why github considers that ltext.ru is completely changed. Updated version uses the same encoding (UTF8), and same newlines (\r\n) as the original one. 

Anyway, the only change in the ltext.ru is in line 2.