### PR TITLE
Fixed #395. Also, updated dist build components

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,68 @@
-wcm (0.18.1-1) unstable; urgency=medium
-  * Added: speed indicator while copying
-  * Hotkey: Ctrl+L to open info dialog
+wcm (0.19.0-1) stable; urgency=medium
+  * Added: Shift+Enter opens a file/folder with the default OS application
+  * Added: bookmarks in the editor (set via RightCtrl+digit, restore via LeftCtrl+digit)
+  * Added: adjust font size with Ctrl+WheelUp, Ctrl+WheelDn (Windows-only)
+  * Added: basic SSH keys SFTP authorization
+  * Added: temporary panel
+  * Added: mark truncated file names with the '}' symbol in panels
+  * Added: store FTP passwords between sessions
+  * Added: folders history (Alt+F12)
+  * Added: file attributes dialog (Ctrl+A)
+  * Added: command line autocompletion shows file/folder names from the current folder
+  * Added: pressing F3 on '..' calculates the size of the current folder
+  * Added: typing in the viewer opens the search dialog
+  * Added: maximize window (Alt+F9)
+  * Hotkey: Ctrl+Alt+Ins, Alt+Shift+Ins, Ctrl+Shift+P to copy the full path of the currently selected item to the clipboard
+  * Hotkey: Ctrl+R to refresh the drives list in the drive selection dialog
+  * Hotkey: Ctrl+NumPadPlus, Ctrl+NumPadMinus to select and deselect files with the same extension
+  * Improved: 'cd' in the command line without arguments should change directory to $HOME
+  * Improved: hotkeys in the F2 user menu
+  * Improved: hotkeys in all 'red' dialogs
+  * Improved: retain cursor position after F5/F6 etc.
+  * Improved: rendering of folders with unicode names (normalized unicode strings)
+  * Improved: C++11 highlighting in the editor
+  * Fixed: button bar text in the editor
+  * Fixed: hotkeys in the 'Styles' dialog
+  * Fixed: OpenBSD support
+  * Fixed: installation issues
+  * Fixed: TrueType fonts antialiasing
+  * Fixed: debug messages in the console
+  * Fixed: mouse interaction bugs
+  * Fixed: graphical issue in the current path under the panels
+  * Fixed: hide the autocompletion window while switching via Ctrl+Tab to the editor/viewer
+  * Fixed: panel width after exiting the editor with Ctrl+Tab
+  * Fixed: pressing Alt+key freezes Ctrl/Shift info in the bottom bar
+  * Fixed: custom highlighting rules for selected files
+  * Fixed: shortcuts in the text search/replace dialogs
+  * Fixed: long path truncation in the drive selection dialog
+  * Fixed: selection color in the viewer
 
+ -- Sergey Kosarevsky <sk@linderdaum.com>  Sat, 21 Feb 2015 23:44:06 -0500
+
+wcm (0.18.1-1) unstable; urgency=medium
+  * Added: file highlighting
+  * Added: speed indicator while copying
+  * Added: color and icon (optional) for soft links
+  * Added: copy multiple selected file names to the clipboard
+  * Added: option to disable setup auto saving
+  * Added: option to show/hide the main menu
+  * Added: show '(Administrator)' in the window caption while running with admin privileges on Windows
+  * Added: show volume label in the drive selection dialog
+  * Added: user menu (F2)
+  * Added: status bar for Alt+... keys in the aditor
+  * Hotkey: Ctrl+L to open info dialog
+  * Hotkey: Ctrl+S to select file (same as Ins)
+  * Hotkey: Ctrl+F12 to select sorting mode
+  * Improved: eye-gouging borders in the main menu
+  * Improved: icons centering in the panels
+  * Fixed: hotkeys in the drive selection dialog
+  * Fixed: up/down in Alt-search
+  * Fixed: numpad Ins and numpad Del
+  * Fixed: keyboard hotkeys in the 'Folder shortcuts' dialog
+  * Development: configs and makefiles moved to the root folder
+  * Development: command line option --debug-keyboard to print keypresses
+  * Development: INSTALL_TO variable to change the installation path
+ 
  -- Sergey Kosarevsky <sk@linderdaum.com>  Mon, 12 Nov 2014 15:56:25 +0300
 
 wcm (0.18.0-1) unstable; urgency=medium

--- a/debian/rpmfix.sh
+++ b/debian/rpmfix.sh
@@ -1,0 +1,55 @@
+#
+#rpmfix.sh 2014-09-25
+#
+#The problem:
+#After 'alien --to-rpm pkgfile.deb' RPM wcm package claims
+#ownership to several system folders: / /usr /usr/bin et.al.
+#This breaks installation on Fedora, by raising
+#file conflict with 'filesystem' package, which owns
+#these files.
+#
+#The script extracts data from RRM, and repackages 
+#it in RPM-native way, i.e. with 'rpmbuild' tool using 
+#custom spec file. The spec file should have file list without 
+#'/', and other common folders.
+#
+#
+
+if [ -z $2 ]
+then
+echo Usage $0 packagefile.rpm specfile.spec
+exit 1
+fi
+ 
+PKG=$1
+PKG=`echo $PKG | sed 's/\.rpm$//'`
+if [ ! -f ${PKG}.rpm ]
+then
+echo missing  ${PKG}.rpm
+exit 2
+fi
+
+
+#SPECFILE=`echo ${PKG}| sed s/\.[^\.]*$//`.spec
+SPECFILE=$2
+
+if [ ! -f ${SPECFILE} ]
+then
+echo "missing spec file: " $SPECFILE
+exit 3
+fi
+
+#PKGDIR=~/rpmbuild/BUILDROOT/${PKG}
+PKGDIR=`pwd`/PKG
+ARCH=`echo ${PKG} | sed 's/^.*\.//g'`
+
+echo rebuilding $PKG on arch $ARCH
+rpm2cpio ${PKG}.rpm | \
+( \
+rm -rf ${PKGDIR} && \
+mkdir -p ${PKGDIR} && \
+cd ${PKGDIR} && \
+cpio -idmv \
+) && \
+rpmbuild -bb  ${SPECFILE} --buildroot ${PKGDIR} --target $ARCH && \
+echo Done. Fixed RPM is: ${HOME}/rpmbuild/RPMS/$ARCH/${PKG}.rpm

--- a/debian/wcm-0.17.1.spec
+++ b/debian/wcm-0.17.1.spec
@@ -1,0 +1,21 @@
+Name: wcm 
+Version: 0.17.1
+Release: 4
+Summary: Wal Commander. Dual panel file manager 
+License: MIT
+Distribution: blah
+Group: blah
+Packager: me
+#requires: libX11, freetype, libsmbclient, libssh2, libstdc++ 
+
+%description
+Wal Commander GitHub Edition dual panel file manager.
+ The purpose of this project is to create a multi-platform open source dual panel file manager
+ (Windows, Linux, FreeBSD, OS X) mimicking the look-n-feel of Far Manager.
+ Currently Wal Commander runs on Windows, Linux and FreeBSD.
+
+%files
+/usr/bin/wcm
+/usr/share/applications/wcm.desktop
+/usr/share/doc/wcm
+/usr/share/wcm

--- a/debian/wcm-0.19.0.spec
+++ b/debian/wcm-0.19.0.spec
@@ -1,0 +1,22 @@
+Name: wcm 
+Version: 0.19.0
+Release: 2
+Summary: Wal Commander. Dual panel file manager 
+License: MIT
+Distribution: blah
+Group: blah
+Packager: me
+#requires: libX11, freetype, libsmbclient, libssh2, libstdc++ 
+
+%description
+Wal Commander GitHub Edition dual panel file manager.
+ The purpose of this project is to create a multi-platform open source dual panel file manager
+ (Windows, Linux, FreeBSD, OS X) mimicking the look-n-feel of Far Manager.
+ Currently Wal Commander runs on Windows, Linux and FreeBSD.
+
+%files
+/usr/bin/wcm
+/usr/share/applications/wcm.desktop
+/usr/share/pixmaps/wcm.png
+/usr/share/doc/wcm
+/usr/share/wcm

--- a/src/wal/wal.cpp
+++ b/src/wal/wal.cpp
@@ -484,7 +484,7 @@ namespace wal
 #if !defined(_WIN32)
 		uint8_t* NormString = utf8proc_NFC( (const uint8_t*)Str );
 
-		if(!NormString) return std::string();
+		if(!NormString) return std::string(Str);
 		
 		std::string Result = (const char*)NormString;
 

--- a/src/wal/wal.cpp
+++ b/src/wal/wal.cpp
@@ -484,6 +484,8 @@ namespace wal
 #if !defined(_WIN32)
 		uint8_t* NormString = utf8proc_NFC( (const uint8_t*)Str );
 
+		if(!NormString) return std::string();
+		
 		std::string Result = (const char*)NormString;
 
 		free( NormString );

--- a/wcm_codeblocks.cbp
+++ b/wcm_codeblocks.cbp
@@ -200,6 +200,7 @@
 		<Unit filename="src/ext-app.cpp" />
 		<Unit filename="src/ext-app.h" />
 		<Unit filename="src/fileassociations.cpp" />
+		<Unit filename="src/fileattributes.cpp" />
 		<Unit filename="src/filehighlighting.cpp" />
 		<Unit filename="src/fileopers.cpp" />
 		<Unit filename="src/fileopers.h" />


### PR DESCRIPTION
My test case of #395 was still failing after the commit  7b8ff0d. It did pass with the fix below. 

Note that this is palliative fix. Wcm now shows empty string instead on broken UTF8 filename. It is better to follow standard approach to show '?' mark in place of bad UTF symbol, and allow user to handle file with the broken name in some way.
