### PR TITLE
Implemented #80 history in all edit lines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,10 @@ src/obj/wcm.res
 *.depend
 *.layout
 
+#Generated Xcode project files, using command:
+#  cmake -G Xcode ..
+xcode.generated/
+
 build/
 Debug/
 Release/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,7 @@ SET(wcm_COMMON_SOURCES
 	path-list.cpp
 	folder-shortcuts.cpp
 	folder-history.cpp
+	nceditline.cpp
 	smblogon.cpp
 	strconfig.cpp
 	strmasks.cpp
@@ -219,6 +220,7 @@ SET(wcm_HEADERS
 	path-list.h
 	folder-shortcuts.h
 	folder-history.h
+	nceditline.h
 	smblogon.h
 	strconfig.h
 	swl/swl.h

--- a/src/fileattributes.cpp
+++ b/src/fileattributes.cpp
@@ -249,7 +249,8 @@ bool FileAttributesDlg( NCDialogParent* Parent, PanelWin* Panel )
 		if ( Node )
 		{
 			FSPath fspath;
-			clPtr<FS> fs = ParzeURI( Dialog.GetURI().GetUnicode(), fspath, {} );
+			FSString URI = Dialog.GetURI();
+			clPtr<FS> fs = ParzeURI( URI.GetUnicode(), fspath, {} );
 			if ( fs )
 			{
 				int Err = 0;

--- a/src/ftplogon.cpp
+++ b/src/ftplogon.cpp
@@ -7,9 +7,10 @@
 #include "ftplogon.h"
 
 #include "ncdialogs.h"
-#include "operthread.h" //для carray_cat
+#include "operthread.h"
 #include "charsetdlg.h"
 #include "ltext.h"
+#include "nceditline.h"
 
 
 class FtpLogonDialog: public NCVertDialog
@@ -24,8 +25,8 @@ public:
 	StaticLine charsetIdText;
 	int charset;
 
-	EditLine serverEdit;
-	EditLine userEdit;
+	NCEditLine serverEdit;
+	NCEditLine userEdit;
 	EditLine passwordEdit;
 	EditLine portEdit;
 	Button charsetButton;
@@ -52,8 +53,8 @@ FtpLogonDialog::FtpLogonDialog( NCDialogParent* parent, FSFtpParam& params )
 	   charsetText( 0, this, utf8_to_unicode( _LT( "&Charset:" ) ).data(), &charsetButton ),
 	   charsetIdText( 0, this, utf8_to_unicode( "***************" ).data() ), // placeholder
 	   charset( params.charset ),
-	   serverEdit  ( 0, this, 0, 0, 16 ),
-	   userEdit ( 0, this, 0, 0, 16 ),
+		serverEdit( "ftp-server", 0, this, 0, 16, 7, false, true, false ),
+		userEdit( "ftp-user", 0, this, 0, 16, 7, false, true, false ),
 	   passwordEdit   ( 0, this, 0, 0, 16 ),
 	   portEdit ( 0, this, 0, 0, 16 ),
 	   charsetButton( 0, this, utf8_to_unicode( ">" ).data() , 1000 ),
@@ -215,8 +216,12 @@ bool GetFtpLogon( NCDialogParent* parent, FSFtpParam& params )
 
 	if ( dlg.DoModal() == CMD_OK )
 	{
-		params.server  = dlg.serverEdit.GetTextStr();
+		params.server = dlg.serverEdit.GetTextStr();
+		dlg.serverEdit.AddCurrentTextToHistory();
+		
 		params.user = dlg.userEdit.GetTextStr();
+		dlg.userEdit.AddCurrentTextToHistory();
+		
 		params.pass = dlg.passwordEdit.GetTextStr();
 		params.port = atoi( dlg.portEdit.GetTextStr().c_str() );
 		params.anonymous = dlg.anonymousButton.IsSet();

--- a/src/ftplogon.cpp
+++ b/src/ftplogon.cpp
@@ -53,8 +53,8 @@ FtpLogonDialog::FtpLogonDialog( NCDialogParent* parent, FSFtpParam& params )
 	   charsetText( 0, this, utf8_to_unicode( _LT( "&Charset:" ) ).data(), &charsetButton ),
 	   charsetIdText( 0, this, utf8_to_unicode( "***************" ).data() ), // placeholder
 	   charset( params.charset ),
-		serverEdit( "ftp-server", 0, this, 0, 16, 7, false, true, false ),
-		userEdit( "ftp-user", 0, this, 0, 16, 7, false, true, false ),
+		serverEdit( EDIT_FIELD_FTP_SERVER, 0, this, 0, 16, 7, false, true, false ),
+		userEdit( EDIT_FIELD_FTP_USER, 0, this, 0, 16, 7, false, true, false ),
 	   passwordEdit   ( 0, this, 0, 0, 16 ),
 	   portEdit ( 0, this, 0, 0, 16 ),
 	   charsetButton( 0, this, utf8_to_unicode( ">" ).data() , 1000 ),

--- a/src/ftplogon.cpp
+++ b/src/ftplogon.cpp
@@ -25,8 +25,8 @@ public:
 	StaticLine charsetIdText;
 	int charset;
 
-	NCEditLine serverEdit;
-	NCEditLine userEdit;
+	clNCEditLine serverEdit;
+	clNCEditLine userEdit;
 	EditLine passwordEdit;
 	EditLine portEdit;
 	Button charsetButton;

--- a/src/makefile.linux
+++ b/src/makefile.linux
@@ -97,6 +97,7 @@ HN = \
 	src/path-list.h \
 	src/folder-shortcuts.h \
 	src/folder-history.h \
+	src/nceditline.h \
 	src/fontdlg.h \
 	src/ncfonts.h \
 	src/shl.h \
@@ -157,6 +158,7 @@ OBJS = \
 	$(OBJDIR)/path-list.o \
 	$(OBJDIR)/folder-shortcuts.o \
 	$(OBJDIR)/folder-history.o \
+	$(OBJDIR)/nceditline.o \
 	$(OBJDIR)/smblogon.o \
 	$(OBJDIR)/strconfig.o \
 	$(OBJDIR)/strmasks.o \
@@ -294,6 +296,9 @@ $(OBJDIR)/folder-shortcuts.o: $(HW) $(HS) $(HN) src/folder-shortcuts.cpp
 
 $(OBJDIR)/folder-history.o: $(HW) $(HS) $(HN) src/folder-history.cpp 
 	$(CC) $(COPTS) -c $(CFLAGS) src/folder-history.cpp -o $(OBJDIR)/folder-history.o
+
+$(OBJDIR)/nceditline.o: $(HW) $(HS) $(HN) src/nceditline.cpp 
+	$(CC) $(COPTS) -c $(CFLAGS) src/nceditline.cpp -o $(OBJDIR)/nceditline.o
 
 $(OBJDIR)/fileassociations.o: $(HW) $(HS) $(HN) src/fileassociations.cpp 
 	$(CC) $(COPTS) -c $(CFLAGS) src/fileassociations.cpp -o $(OBJDIR)/fileassociations.o

--- a/src/makefile.windows
+++ b/src/makefile.windows
@@ -57,6 +57,7 @@ HN = \
 	src/path-list.h \
 	src/folder-shortcuts.h \
 	src/folder-history.h \
+	src/nceditline.h \
 	src/fontdlg.h \
 	src/ncfonts.h \
 	src/shl.h \
@@ -115,6 +116,7 @@ OBJS = \
 	$(OBJDIR)/path-list.o \
 	$(OBJDIR)/folder-shortcuts.o \
 	$(OBJDIR)/folder-history.o \
+	$(OBJDIR)/nceditline.o \
 	$(OBJDIR)/smblogon.o \
 	$(OBJDIR)/strconfig.o \
 	$(OBJDIR)/strmasks.o \
@@ -230,6 +232,9 @@ $(OBJDIR)/folder-shortcuts.o: $(HW) $(HS) $(HN) src/folder-shortcuts.cpp
 
 $(OBJDIR)/folder-history.o: $(HW) $(HS) $(HN) src/folder-history.cpp 
 	$(CC) $(COPTS) -c $(CFLAGS) src/folder-history.cpp -o $(OBJDIR)/folder-history.o
+
+$(OBJDIR)/nceditline.o: $(HW) $(HS) $(HN) src/nceditline.cpp 
+	$(CC) $(COPTS) -c $(CFLAGS) src/nceditline.cpp -o $(OBJDIR)/nceditline.o
 
 $(OBJDIR)/fileassociations.o: $(HW) $(HS) $(HN) src/fileassociations.cpp 
 	$(CC) $(COPTS) -c $(CFLAGS) src/fileassociations.cpp -o $(OBJDIR)/fileassociations.o

--- a/src/ncdialogs.cpp
+++ b/src/ncdialogs.cpp
@@ -618,7 +618,7 @@ int GoToLineDialog( NCDialogParent* parent )
 	return n;
 }
 
-class InputStrDialogBase abstract : public NCVertDialog
+class InputStrDialogBase : public NCVertDialog
 {
 public:
 	InputStrDialogBase( NCDialogParent* parent, const unicode_t* message )
@@ -627,7 +627,7 @@ public:
 	}
 	virtual ~InputStrDialogBase() {}
 
-	virtual std::vector<unicode_t> GetText() abstract;
+	virtual std::vector<unicode_t> GetText() = 0;
 
 	virtual std::vector<unicode_t> ShowDialog();
 };

--- a/src/ncdialogs.cpp
+++ b/src/ncdialogs.cpp
@@ -13,6 +13,7 @@
 #include "ltext.h"
 #include "unicode_lc.h"
 #include "panel.h"
+#include "nceditline.h"
 
 bool createDialogAsChild //= false;
    = true;
@@ -454,6 +455,12 @@ NCDialog::~NCDialog()
 
 bool NCVertDialog::EventChildKey( Win* child, cevent_key* pEvent )
 {
+    // try to preprocess key combinations like Cntrl + VK_DOWN
+    if ( dynamic_cast<NCEditLine*>(child) && child->EventKey(pEvent) )
+    {
+        return true;
+    }
+
 	if ( pEvent->Type() == EV_KEYDOWN )
 	{
 		if ( pEvent->Key() == VK_UP || pEvent->Key() == VK_DOWN )
@@ -483,9 +490,9 @@ bool NCVertDialog::EventChildKey( Win* child, cevent_key* pEvent )
 
 			return true;
 		}
-	};
+	}
 
-	return NCDialog::EventChildKey( child, pEvent );
+    return NCDialog::EventChildKey( child, pEvent );
 }
 
 

--- a/src/ncdialogs.cpp
+++ b/src/ncdialogs.cpp
@@ -456,7 +456,7 @@ NCDialog::~NCDialog()
 bool NCVertDialog::EventChildKey( Win* child, cevent_key* pEvent )
 {
     // try to preprocess key combinations like Cntrl + VK_DOWN
-    if ( dynamic_cast<NCEditLine*>(child) && child->EventKey(pEvent) )
+    if ( dynamic_cast<clNCEditLine*>(child) && child->EventKey(pEvent) )
     {
         return true;
     }
@@ -618,26 +618,25 @@ int GoToLineDialog( NCDialogParent* parent )
 	return n;
 }
 
-class InputStrDialogBase : public NCVertDialog
+class clInputStrDialogBase : public NCVertDialog
 {
 public:
-	InputStrDialogBase( NCDialogParent* parent, const unicode_t* message )
-		: NCVertDialog( ::createDialogAsChild, 0, parent, message, bListOkCancel )
+	clInputStrDialogBase( NCDialogParent* Parent, const unicode_t* Message )
+		: NCVertDialog( ::createDialogAsChild, 0, Parent, Message, bListOkCancel )
 	{
 	}
-	virtual ~InputStrDialogBase() {}
+	virtual ~clInputStrDialogBase() {}
 
-	virtual std::vector<unicode_t> GetText() = 0;
+	virtual std::vector<unicode_t> GetText() const = 0;
 
 	virtual std::vector<unicode_t> ShowDialog();
 };
 
-std::vector<unicode_t> InputStrDialogBase::ShowDialog()
+std::vector<unicode_t> clInputStrDialogBase::ShowDialog()
 {
 	SetEnterCmd( CMD_OK );
 
-	const int r = DoModal();
-	if ( r != CMD_OK )
+	if ( DoModal() != CMD_OK )
 	{
 		return std::vector<unicode_t>();
 	}
@@ -646,96 +645,96 @@ std::vector<unicode_t> InputStrDialogBase::ShowDialog()
 }
 
 
-class InputStrDialog : public InputStrDialogBase
+class clInputStrDialog : public clInputStrDialogBase
 {
 private:
-	EditLine m_strEdit;
+	EditLine m_StrEdit;
 
 public:
-	InputStrDialog( NCDialogParent* parent, const unicode_t* message, const unicode_t* str )
-		: InputStrDialogBase( parent, message )
-		, m_strEdit( 0, (Win*)this, 0, 0, 100 )
+	clInputStrDialog( NCDialogParent* Parent, const unicode_t* Message, const unicode_t* Str )
+		: clInputStrDialogBase( Parent, Message )
+		, m_StrEdit( 0, (Win*) this, 0, 0, 100 )
 	{
-		m_strEdit.Enable();
-		m_strEdit.Show();
-		AddWin( &m_strEdit );
-		order.append( &m_strEdit );
+		m_StrEdit.Enable();
+		m_StrEdit.Show();
+		AddWin( &m_StrEdit );
+		order.append( &m_StrEdit );
 
-		if ( str )
+		if ( Str )
 		{
-			m_strEdit.SetText( str, true );
+			m_StrEdit.SetText( Str, true );
 		}
 
-		m_strEdit.SetFocus();
+		m_StrEdit.SetFocus();
 		SetPosition();
 	}
-	virtual ~InputStrDialog() {}
+	virtual ~clInputStrDialog() {}
 
-	std::vector<unicode_t> GetText() override
+	virtual std::vector<unicode_t> GetText() const override
 	{
-		return m_strEdit.GetText();
+		return m_StrEdit.GetText();
 	}
 };
 
 
-class InputFieldDialog : public InputStrDialogBase
+class clInputFieldDialog : public clInputStrDialogBase
 {
 private:
-	NCEditLine m_fieldEdit;
+	clNCEditLine m_FieldEdit;
 
 public:
-	InputFieldDialog( const char* fieldName, NCDialogParent* parent, const unicode_t* message, const unicode_t* str )
-		: InputStrDialogBase( parent, message )
-		, m_fieldEdit( fieldName, 0, (Win*)this, 0, 100, 7, false, true, false )
+	clInputFieldDialog( const char* FieldName, NCDialogParent* Parent, const unicode_t* Message, const unicode_t* Str )
+		: clInputStrDialogBase( Parent, Message )
+		, m_FieldEdit( FieldName, 0, (Win*)this, 0, 100, 7, false, true, false )
 	{
-		m_fieldEdit.Enable();
-		m_fieldEdit.Show();
-		AddWin( &m_fieldEdit );
-		order.append( &m_fieldEdit );
+		m_FieldEdit.Enable();
+		m_FieldEdit.Show();
+		AddWin( &m_FieldEdit );
+		order.append( &m_FieldEdit );
 
-		if ( str )
+		if ( Str )
 		{
-			m_fieldEdit.SetText( str, true );
+			m_FieldEdit.SetText( Str, true );
 		}
 
-		m_fieldEdit.SetFocus();
+		m_FieldEdit.SetFocus();
 		SetPosition();
 	}
-	virtual ~InputFieldDialog() {}
+	virtual ~clInputFieldDialog() {}
 
-	std::vector<unicode_t> GetText() override
+	virtual std::vector<unicode_t> GetText() const override
 	{
-		return m_fieldEdit.GetText();
+		return m_FieldEdit.GetText();
 	}
 
-	std::vector<unicode_t> ShowDialog() override
+	virtual std::vector<unicode_t> ShowDialog() override
 	{
-		std::vector<unicode_t> res = InputStrDialogBase::ShowDialog();
-		if ( res.size() > 0 )
+		std::vector<unicode_t> Res = clInputStrDialogBase::ShowDialog();
+		if ( Res.size() > 0 )
 		{
-			m_fieldEdit.AddCurrentTextToHistory();
+			m_FieldEdit.AddCurrentTextToHistory();
 		}
 
-		return res;
+		return Res;
 	}
 };
 
 
-std::vector<unicode_t> InputStringDialog( NCDialogParent* parent, const unicode_t* message, const unicode_t* str )
+std::vector<unicode_t> InputStringDialog( NCDialogParent* Parent, const unicode_t* Message, const unicode_t* Str )
 {
-	return InputStringDialog( nullptr, parent, message, str );
+	return InputStringDialog( nullptr, Parent, Message, Str );
 }
 
-std::vector<unicode_t> InputStringDialog( const char* fieldName, NCDialogParent* parent, const unicode_t* message, const unicode_t* str )
+std::vector<unicode_t> InputStringDialog( const char* FieldName, NCDialogParent* Parent, const unicode_t* Message, const unicode_t* Str )
 {
-	if ( !fieldName )
+	if ( !FieldName )
 	{
-		InputStrDialog d( parent, message, str );
-		return d.ShowDialog();
+		clInputStrDialog Dlg( Parent, Message, Str );
+		return Dlg.ShowDialog();
 	}
 
-	InputFieldDialog d( fieldName, parent, message, str );
-	return d.ShowDialog();
+	clInputFieldDialog Dlg( FieldName, Parent, Message, Str );
+	return Dlg.ShowDialog();
 }
 
 int uiKillCmdDialog = GetUiID( "KillCmdDialog" );

--- a/src/ncdialogs.h
+++ b/src/ncdialogs.h
@@ -12,6 +12,7 @@
 
 using namespace wal;
 
+
 class NCShadowWin: public Win
 {
 public:
@@ -119,7 +120,11 @@ int NCMessageBox( NCDialogParent* parent, const char* utf8head, const char* utf8
 int GoToLineDialog( NCDialogParent* parent );
 int KillCmdDialog( NCDialogParent* parent, const unicode_t* cmd );
 
+// simple input string dialog
 std::vector<unicode_t> InputStringDialog( NCDialogParent* parent, const unicode_t* message, const unicode_t* str = 0 );
+
+// input string dialog with history and auto complete support
+std::vector<unicode_t> InputStringDialog( const char* fieldName, NCDialogParent* parent, const unicode_t* message, const unicode_t* str = 0 );
 
 
 class CmdHistoryDialog: public NCDialog

--- a/src/nceditline.cpp
+++ b/src/nceditline.cpp
@@ -1,0 +1,283 @@
+/*
+* Part of Wal Commander GitHub Edition
+* https://github.com/corporateshark/WalCommander
+* walcommander@linderdaum.com
+*/
+
+#include "nceditline.h"
+#include "wcm-config.h"
+#include "string-util.h"
+
+
+static cstrhash<clPtr<HistCollect>> histHash;
+
+
+inline bool HistoryCanSave()
+{
+    //return wcmConfig.systemSaveHistory;
+    return false;
+}
+
+inline bool AcEnabled()
+{
+    //return wcmConfig.systemAutoComplete;
+    return false;
+}
+
+static std::vector<char> HistSectionName(const char *acGroup)
+{
+	return carray_cat<char>("hist-", acGroup);
+}
+
+HistCollect* HistGetList(const char *histGroup)
+{
+    if (!histGroup || !histGroup[0])
+    {
+        return 0;
+    }
+
+	if (HistoryCanSave())
+	{
+        std::vector<std::string> list;
+        clPtr<HistCollect> pUList = new HistCollect;
+        LoadStringList(HistSectionName(histGroup).data(), list);
+
+        const int n = list.size();
+		for (int i = 0; i < n; i++)
+		{
+            if (list[i].data() && list[i][0])
+                pUList->append(utf8_to_unicode(list[i].data()));
+		}
+
+		histHash[histGroup] = pUList;
+	}
+	
+    clPtr<HistCollect>* pp = histHash.exist(histGroup);
+	if (pp && pp->ptr()) return pp->ptr();
+
+    clPtr<HistCollect> pUList = new HistCollect;
+	HistCollect *pList = pUList.ptr();
+	histHash[histGroup] = pUList;
+
+	return pList;
+}
+
+static bool HistStrcmp(const unicode_t *a, const unicode_t *b)
+{
+    while (*a && *b && *a == *b)
+    {
+        a++;
+        b++;
+    }
+	
+    while (*a && (*a == ' ' || *a == '\t'))
+    {
+        a++;
+    }
+	
+    while (*b && (*b == ' ' || *b == '\t'))
+    {
+        b++;
+    }
+	
+    return (!*a && !*b);
+}
+
+static void HistCommit(const char *histGroup, const unicode_t *txt)
+{
+    if (!histGroup || !histGroup[0])
+    {
+        return;
+    }
+
+    if (!txt || !txt[0])
+    {
+        return;
+    }
+
+	HistCollect *pList = HistGetList(histGroup);
+    clPtr<HistCollect> pUList = new HistCollect;
+	pUList->append( new_unicode_str(txt) );
+
+	int n = pList->count();
+    for (int i = 0; i < n; i++)
+    {
+        if (!HistStrcmp(txt, pList->get(i).data()))
+        {
+            pUList->append(pList->get(i));
+        }
+    }
+
+	pList = pUList.ptr();
+	histHash[histGroup] = pUList;
+
+	if (HistoryCanSave())
+	{
+        std::vector<std::string> list;
+		int n = pList->count();
+
+        if (n > 50)
+        {
+            n = 50; // limit amount of saved data
+        }
+
+        for (int i = 0; i < n; i++)
+        {
+            list.push_back(unicode_to_utf8_string(pList->get(i).data()));
+        }
+
+        SaveStringList(HistSectionName(histGroup).data(), list);
+	}
+}
+
+static int uiClassNCEditLine = GetUiID("NCEditLine");
+
+int NCEditLine::UiGetClassId()
+{
+	return uiClassNCEditLine;
+}
+
+NCEditLine::NCEditLine(const char *acGroup, int nId, Win *parent, const unicode_t *txt, 
+        int cols, int rows, bool up, bool frame3d, bool nofocusframe, crect *rect)
+    : ComboBox(nId, parent, cols, rows, (up ? ComboBox::MODE_UP: 0) | (frame3d ? ComboBox::FRAME3D : 0) | (nofocusframe ? ComboBox::NOFOCUSFRAME : 0), rect)
+    , _group(acGroup)
+    , _autoMode(false)
+{
+}
+
+void NCEditLine::Clear()
+{
+	CloseBox();
+	
+    static unicode_t s0 = 0;
+	SetText(&s0);
+}
+
+bool NCEditLine::Command(int id, int subId, Win *win, void *d)
+{
+	if (IsEditLine(win))
+	{
+		if (AcEnabled())
+		{
+            if (IsBoxOpened() && !_autoMode)
+            {
+                return false;
+            }
+
+            if (!_histList.ptr())
+            {
+                LoadHistoryList();
+            }
+
+            std::vector<unicode_t> text = GetText();
+
+            SetCBList(text.data());
+
+            unicode_t *u = text.data();
+            while (*u == ' ' || *u == '\t')
+            {
+                u++;
+            }
+
+			if (ComboBox::Count() > 0 && *u) 
+			{
+				_autoMode = true;
+				OpenBox();
+            }
+            else
+            {
+                CloseBox();
+            }
+		}
+		
+        return true;
+	}
+
+	return ComboBox::Command(id, subId, win, d);
+}
+
+static bool AcEqual(const unicode_t *txt, const unicode_t *element)
+{
+    if (!txt)
+    {
+        return true;
+    }
+	
+    if (!element)
+    {
+        return false;
+    }
+
+    while (*txt && *element && *txt == *element)
+    {
+        txt++;
+        element++;
+    }
+	
+    return *txt == 0;
+}
+
+void NCEditLine::SetCBList(const unicode_t *txt)
+{
+	ComboBox::Clear();
+	
+    if (!_histList.ptr())
+    {
+        return;
+    }
+	
+    const int n = _histList->count();
+	for (int i = 0; i < n; i++)
+	{
+        const unicode_t *u = _histList->get(i).data();
+        if (u && AcEqual(txt, u))
+        {
+            ComboBox::Append(u);
+        }
+	}
+
+	ComboBox::MoveCurrent(-1);
+	ComboBox::RefreshBox();
+}
+
+void NCEditLine::LoadHistoryList()
+{
+	HistCollect* p = HistGetList(_group);
+	if (p)
+    {
+		_histList = new HistCollect;
+		const int n = p->count();
+        for (int i = 0; i < n; i++)
+        {
+            _histList->append(new_unicode_str(p->get(i).data()));
+        }
+	}
+}
+
+bool NCEditLine::OnOpenBox()
+{
+    if (!_group || !_group[0])
+    {
+        return false;
+    }
+
+	if (!_histList.ptr())
+    {
+		LoadHistoryList();
+	}
+
+    SetCBList(_autoMode ? GetText().data() : 0);
+	return true;
+}
+
+void NCEditLine::OnCloseBox()
+{
+	_autoMode = false;
+}
+
+void NCEditLine::Commit()
+{
+    HistCommit(_group, GetText().data());
+	_histList = 0;
+}
+

--- a/src/nceditline.cpp
+++ b/src/nceditline.cpp
@@ -8,13 +8,8 @@
 #include "string-util.h"
 #include "unicode_lc.h"
 #include "nchistory.h"
+#include "globals.h"
 
-
-inline bool AcEnabled()
-{
-	//return wcmConfig.systemAutoComplete;
-	return true;
-}
 
 static int uiClassNCEditLine = GetUiID( "NCEditLine" );
 
@@ -72,7 +67,7 @@ bool AcEqual( const unicode_t* txt, const unicode_t* element, int chars )
 
 bool NCEditLine::Command( int id, int subId, Win* win, void* d )
 {
-	if ( id == CMD_EDITLINE_INFO && subId == SCMD_EDITLINE_INSERTED && IsEditLine( win ) && AcEnabled() )
+	if ( id == CMD_EDITLINE_INFO && subId == SCMD_EDITLINE_INSERTED && IsEditLine( win ) && g_WcmConfig.systemAutoComplete )
 	{
 		std::vector<unicode_t> text = GetText();
 		const int cursorPos = GetCursorPos();

--- a/src/nceditline.cpp
+++ b/src/nceditline.cpp
@@ -13,93 +13,92 @@
 
 static int uiClassNCEditLine = GetUiID( "NCEditLine" );
 
-int NCEditLine::UiGetClassId()
+int clNCEditLine::UiGetClassId()
 {
 	return uiClassNCEditLine;
 }
 
-NCEditLine::NCEditLine( const char* fieldName, int nId, Win* parent, const unicode_t* txt,
-	int cols, int rows, bool up, bool frame3d, bool nofocusframe, crect* rect )
-	: ComboBox( nId, parent, cols, rows,
-				  (up ? ComboBox::MODE_UP : 0) | (frame3d ? ComboBox::FRAME3D : 0) | (nofocusframe ? ComboBox::NOFOCUSFRAME : 0),
-				  rect )
-	, m_fieldName( fieldName )
+clNCEditLine::clNCEditLine( const char* FieldName, int Id, Win* Parent, const unicode_t* Txt,
+									int Cols, int Rows, bool Up, bool Frame3d, bool NoFocusFrame, crect* Rect )
+	: ComboBox( Id, Parent, Cols, Rows,
+				  (Up ? ComboBox::MODE_UP : 0) | (Frame3d ? ComboBox::FRAME3D : 0) | (NoFocusFrame ? ComboBox::NOFOCUSFRAME : 0),
+				  Rect )
+	, m_FieldName( FieldName )
 {
-	HistCollect* pList = GetFieldHistCollect( m_fieldName );
-	if ( pList )
+	HistCollect_t* List = GetFieldHistCollect( m_FieldName );
+	if ( List )
 	{
-		for ( int i = 0, count = pList->size(); i < count; i++ )
+		for ( int i = 0, count = List->size(); i < count; i++ )
 		{
-			const unicode_t* u = pList->at( i ).data();
-			if ( u )
+			const unicode_t* Str = List->at( i ).data();
+			if ( Str )
 			{
-				Append( u );
+				Append( Str );
 			}
 		}
 	}
 	else
 	{
-		static unicode_t s0 = 0;
-		Append( &s0 );
+		static unicode_t Str0 = 0;
+		Append( &Str0 );
 	}
 }
 
-bool AcEqual( const unicode_t* txt, const unicode_t* element, int chars )
+bool AcEqual( const unicode_t* Txt, const unicode_t* Element, int Chars )
 {
-	if ( !txt || !element || chars <= 0 )
+	if ( !Txt || !Element || Chars <= 0 )
 	{
 		return false;
 	}
 
-	while ( *txt && *element && UnicodeLC( *txt ) == UnicodeLC( *element ) )
+	while ( *Txt && *Element && UnicodeLC( *Txt ) == UnicodeLC( *Element ) )
 	{
-		if ( --chars == 0 )
+		if ( --Chars == 0 )
 		{
 			return true;
 		}
 
-		txt++;
-		element++;
+		Txt++;
+		Element++;
 	}
 
 	return false;
 }
 
-bool NCEditLine::Command( int id, int subId, Win* win, void* d )
+bool clNCEditLine::Command( int Id, int SubId, Win* Win, void* Data )
 {
-	if ( id == CMD_EDITLINE_INFO && subId == SCMD_EDITLINE_INSERTED && IsEditLine( win ) && g_WcmConfig.systemAutoComplete )
+	if ( Id == CMD_EDITLINE_INFO && SubId == SCMD_EDITLINE_INSERTED && IsEditLine( Win ) && g_WcmConfig.systemAutoComplete )
 	{
-		std::vector<unicode_t> text = GetText();
-		const int cursorPos = GetCursorPos();
+		std::vector<unicode_t> Text = GetText();
+		const int CursorPos = GetCursorPos();
 		
 		// try to autocomplete when cursor is at the end of unmarked text
-		if ( ((int)text.size() - 1) == cursorPos )
+		if ( ((int)Text.size() - 1) == CursorPos )
 		{
 			const int count = Count();
 			for ( int i = 0; i < count; i++ )
 			{
-				const unicode_t* item = ItemText( i );
-				if ( AcEqual( text.data(), item, cursorPos ) )
+				const unicode_t* Item = ItemText( i );
+				if ( AcEqual( Text.data(), Item, CursorPos ) )
 				{
 					// append suffix of the history item's text to the current text
-					SetText( carray_cat( text.data(), item + cursorPos ).data() );
+					SetText( carray_cat( Text.data(), Item + CursorPos ).data() );
 					
 					// select the auto-completed part of text
-					SetCursorPos( carray_len( item ) );
-					SetCursorPos( cursorPos, true );
+					SetCursorPos( carray_len( Item ) );
+					SetCursorPos( CursorPos, true );
 					return true;
 				}
 			}
 		}
 	}
 
-	return ComboBox::Command( id, subId, win, d );
+	return ComboBox::Command( Id, SubId, Win, Data );
 }
 
-bool NCEditLine::OnOpenBox()
+bool clNCEditLine::OnOpenBox()
 {
-	const int count = Count();
-	if ( count > 0 )
+	if ( Count() > 0 )
 	{
 		MoveCurrent( 0 );
 	}
@@ -107,7 +106,7 @@ bool NCEditLine::OnOpenBox()
 	return true;
 }
 
-void NCEditLine::AddCurrentTextToHistory()
+void clNCEditLine::AddCurrentTextToHistory()
 {
-	AddFieldTextToHistory( m_fieldName, GetText().data() );
+	AddFieldTextToHistory( m_FieldName, GetText().data() );
 }

--- a/src/nceditline.cpp
+++ b/src/nceditline.cpp
@@ -9,275 +9,292 @@
 #include "string-util.h"
 
 
+typedef ccollect<std::vector<unicode_t>> HistCollect;
+
 static cstrhash<clPtr<HistCollect>> histHash;
 
 
 inline bool HistoryCanSave()
 {
-    //return wcmConfig.systemSaveHistory;
-    return false;
+	//return wcmConfig.systemSaveHistory;
+	return true;
 }
 
 inline bool AcEnabled()
 {
-    //return wcmConfig.systemAutoComplete;
-    return false;
+	//return wcmConfig.systemAutoComplete;
+	return true;
 }
 
-static std::vector<char> HistSectionName(const char *acGroup)
+std::vector<char> HistSectionName( const char* fieldName )
 {
-	return carray_cat<char>("hist-", acGroup);
+	return carray_cat<char>( "history-field-", fieldName );
 }
 
-HistCollect* HistGetList(const char *histGroup)
+HistCollect* HistGetList( const char* fieldName )
 {
-    if (!histGroup || !histGroup[0])
-    {
-        return 0;
-    }
+	HistCollect* list = new HistCollect;
+	list->append( utf8_to_unicode( "test" ) );
+	list->append( utf8_to_unicode( "test 2" ) );
+	list->append( utf8_to_unicode( "test 3" ) );
+	return list;
 
-	if (HistoryCanSave())
+	if ( !fieldName || !fieldName[0] )
 	{
-        std::vector<std::string> list;
-        clPtr<HistCollect> pUList = new HistCollect;
-        LoadStringList(HistSectionName(histGroup).data(), list);
+		return 0;
+	}
 
-        const int n = list.size();
-		for (int i = 0; i < n; i++)
+	if ( HistoryCanSave() )
+	{
+		std::vector<std::string> list;
+		clPtr<HistCollect> pUList = new HistCollect;
+		LoadStringList( HistSectionName( fieldName ).data(), list );
+
+		const int n = list.size();
+		for ( int i = 0; i < n; i++ )
 		{
-            if (list[i].data() && list[i][0])
-                pUList->append(utf8_to_unicode(list[i].data()));
+			if ( list[i].data() && list[i][0] )
+			{
+				pUList->append( utf8_to_unicode( list[i].data() ) );
+			}
 		}
 
-		histHash[histGroup] = pUList;
+		histHash[fieldName] = pUList;
 	}
-	
-    clPtr<HistCollect>* pp = histHash.exist(histGroup);
-	if (pp && pp->ptr()) return pp->ptr();
 
-    clPtr<HistCollect> pUList = new HistCollect;
+	clPtr<HistCollect>* pp = histHash.exist( fieldName );
+	if ( pp && pp->ptr() )
+	{
+		return pp->ptr();
+	}
+
+	clPtr<HistCollect> pUList = new HistCollect;
 	HistCollect *pList = pUList.ptr();
-	histHash[histGroup] = pUList;
+	histHash[fieldName] = pUList;
 
 	return pList;
 }
 
-static bool HistStrcmp(const unicode_t *a, const unicode_t *b)
+bool HistStrcmp( const unicode_t* a, const unicode_t* b )
 {
-    while (*a && *b && *a == *b)
-    {
-        a++;
-        b++;
-    }
-	
-    while (*a && (*a == ' ' || *a == '\t'))
-    {
-        a++;
-    }
-	
-    while (*b && (*b == ' ' || *b == '\t'))
-    {
-        b++;
-    }
-	
-    return (!*a && !*b);
+	while ( *a && *b && *a == *b )
+	{
+		a++;
+		b++;
+	}
+
+	while ( *a && (*a == ' ' || *a == '\t') )
+	{
+		a++;
+	}
+
+	while ( *b && (*b == ' ' || *b == '\t') )
+	{
+		b++;
+	}
+
+	return (!*a && !*b);
 }
 
-static void HistCommit(const char *histGroup, const unicode_t *txt)
+void HistCommit( const char* fieldName, const unicode_t* txt )
 {
-    if (!histGroup || !histGroup[0])
-    {
-        return;
-    }
+	if ( !fieldName || !fieldName[0] )
+	{
+		return;
+	}
 
-    if (!txt || !txt[0])
-    {
-        return;
-    }
+	if ( !txt || !txt[0] )
+	{
+		return;
+	}
 
-	HistCollect *pList = HistGetList(histGroup);
-    clPtr<HistCollect> pUList = new HistCollect;
-	pUList->append( new_unicode_str(txt) );
+	HistCollect *pList = HistGetList( fieldName );
+	clPtr<HistCollect> pUList = new HistCollect;
+	pUList->append( new_unicode_str( txt ) );
 
 	int n = pList->count();
-    for (int i = 0; i < n; i++)
-    {
-        if (!HistStrcmp(txt, pList->get(i).data()))
-        {
-            pUList->append(pList->get(i));
-        }
-    }
+	for ( int i = 0; i < n; i++ )
+	{
+		if ( !HistStrcmp( txt, pList->get( i ).data() ) )
+		{
+			pUList->append( pList->get( i ) );
+		}
+	}
 
 	pList = pUList.ptr();
-	histHash[histGroup] = pUList;
+	histHash[fieldName] = pUList;
 
-	if (HistoryCanSave())
+	if ( HistoryCanSave() )
 	{
-        std::vector<std::string> list;
+		std::vector<std::string> list;
 		int n = pList->count();
 
-        if (n > 50)
-        {
-            n = 50; // limit amount of saved data
-        }
+		if ( n > 50 )
+		{
+			n = 50; // limit amount of saved data
+		}
 
-        for (int i = 0; i < n; i++)
-        {
-            list.push_back(unicode_to_utf8_string(pList->get(i).data()));
-        }
+		for ( int i = 0; i < n; i++ )
+		{
+			list.push_back( unicode_to_utf8_string( pList->get( i ).data() ) );
+		}
 
-        SaveStringList(HistSectionName(histGroup).data(), list);
+		SaveStringList( HistSectionName( fieldName ).data(), list );
 	}
 }
 
-static int uiClassNCEditLine = GetUiID("NCEditLine");
+static int uiClassNCEditLine = GetUiID( "NCEditLine" );
 
 int NCEditLine::UiGetClassId()
 {
 	return uiClassNCEditLine;
 }
 
-NCEditLine::NCEditLine(const char *acGroup, int nId, Win *parent, const unicode_t *txt, 
-        int cols, int rows, bool up, bool frame3d, bool nofocusframe, crect *rect)
-    : ComboBox(nId, parent, cols, rows, (up ? ComboBox::MODE_UP: 0) | (frame3d ? ComboBox::FRAME3D : 0) | (nofocusframe ? ComboBox::NOFOCUSFRAME : 0), rect)
-    , _group(acGroup)
-    , _autoMode(false)
+NCEditLine::NCEditLine( const char* fieldName, int nId, Win* parent, const unicode_t* txt,
+	int cols, int rows, bool up, bool frame3d, bool nofocusframe, crect* rect )
+	: ComboBox( nId, parent, cols, rows, (up ? ComboBox::MODE_UP : 0) | (frame3d ? ComboBox::FRAME3D : 0) | (nofocusframe ? ComboBox::NOFOCUSFRAME : 0), rect )
+	, m_fieldName( fieldName )
+	, m_autoMode( false )
 {
-}
+	clPtr<ccollect<std::vector<unicode_t>>> histList = 0;
 
-void NCEditLine::Clear()
-{
-	CloseBox();
-	
-    static unicode_t s0 = 0;
-	SetText(&s0);
-}
-
-bool NCEditLine::Command(int id, int subId, Win *win, void *d)
-{
-	if (IsEditLine(win))
+	if ( m_fieldName && m_fieldName[0] )
 	{
+		histList = HistGetList( m_fieldName );
+	}
+
+	if ( histList.ptr() )
+	{
+		const int n = histList->count();
+		for ( int i = 0; i < n; i++ )
+		{
+			const unicode_t *u = histList->get( i ).data();
+			if ( u /*&& AcEqual(txt, u)*/ )
+			{
+				Append( u );
+			}
+		}
+
+		//MoveCurrent(-1);
+		//RefreshBox();
+	}
+	else
+	{
+		static unicode_t s0 = 0;
+		Append( &s0 );
+	}
+}
+
+//void NCEditLine::Clear()
+//{
+//	CloseBox();
+//	
+//    static unicode_t s0 = 0;
+//	SetText(&s0);
+//}
+//
+bool NCEditLine::Command( int id, int subId, Win* win, void* d )
+{
+	/*	if (IsEditLine(win))
+		{
 		if (AcEnabled())
 		{
-            if (IsBoxOpened() && !_autoMode)
-            {
-                return false;
-            }
-
-            if (!_histList.ptr())
-            {
-                LoadHistoryList();
-            }
-
-            std::vector<unicode_t> text = GetText();
-
-            SetCBList(text.data());
-
-            unicode_t *u = text.data();
-            while (*u == ' ' || *u == '\t')
-            {
-                u++;
-            }
-
-			if (ComboBox::Count() > 0 && *u) 
-			{
-				_autoMode = true;
-				OpenBox();
-            }
-            else
-            {
-                CloseBox();
-            }
+		if (IsBoxOpened() && !m_autoMode)
+		{
+		return false;
 		}
-		
-        return true;
-	}
 
-	return ComboBox::Command(id, subId, win, d);
+		std::vector<unicode_t> text = GetText();
+		//SetCBList(text.data());
+
+		unicode_t *u = text.data();
+		while (*u == ' ' || *u == '\t')
+		{
+		u++;
+		}
+
+		if (Count() > 0 && *u)
+		{
+		m_autoMode = true;
+		OpenBox();
+		}
+		else
+		{
+		CloseBox();
+		}
+		}
+
+		return true;
+		}
+		*/
+	return ComboBox::Command( id, subId, win, d );
 }
 
-static bool AcEqual(const unicode_t *txt, const unicode_t *element)
+bool AcEqual( const unicode_t* txt, const unicode_t* element )
 {
-    if (!txt)
-    {
-        return true;
-    }
-	
-    if (!element)
-    {
-        return false;
-    }
-
-    while (*txt && *element && *txt == *element)
-    {
-        txt++;
-        element++;
-    }
-	
-    return *txt == 0;
-}
-
-void NCEditLine::SetCBList(const unicode_t *txt)
-{
-	ComboBox::Clear();
-	
-    if (!_histList.ptr())
-    {
-        return;
-    }
-	
-    const int n = _histList->count();
-	for (int i = 0; i < n; i++)
+	if ( !txt )
 	{
-        const unicode_t *u = _histList->get(i).data();
-        if (u && AcEqual(txt, u))
-        {
-            ComboBox::Append(u);
-        }
+		return true;
 	}
 
-	ComboBox::MoveCurrent(-1);
-	ComboBox::RefreshBox();
+	if ( !element )
+	{
+		return false;
+	}
+
+	while ( *txt && *element && *txt == *element )
+	{
+		txt++;
+		element++;
+	}
+
+	return (*txt == 0);
 }
 
-void NCEditLine::LoadHistoryList()
-{
-	HistCollect* p = HistGetList(_group);
-	if (p)
-    {
-		_histList = new HistCollect;
-		const int n = p->count();
-        for (int i = 0; i < n; i++)
-        {
-            _histList->append(new_unicode_str(p->get(i).data()));
-        }
-	}
-}
+//void NCEditLine::SetCBList(const unicode_t* txt)
+//{
+//	Clear();
+//	
+//    if (!m_histList.ptr())
+//    {
+//        return;
+//    }
+//	
+//    const int n = m_histList->count();
+//	for (int i = 0; i < n; i++)
+//	{
+//        const unicode_t *u = m_histList->get(i).data();
+//        if (u && AcEqual(txt, u))
+//        {
+//            Append(u);
+//        }
+//	}
+//
+//	MoveCurrent(-1);
+//	RefreshBox();
+//}
 
 bool NCEditLine::OnOpenBox()
 {
-    if (!_group || !_group[0])
-    {
-        return false;
-    }
+	//   if (!m_histList.ptr())
+	//   {
+	//       return false;
+	//}
 
-	if (!_histList.ptr())
-    {
-		LoadHistoryList();
-	}
-
-    SetCBList(_autoMode ? GetText().data() : 0);
+	//   SetCBList(m_autoMode ? GetText().data() : 0);
+	//MoveCurrent(-1);
+	RefreshBox();
 	return true;
 }
 
 void NCEditLine::OnCloseBox()
 {
-	_autoMode = false;
+	ComboBox::OnCloseBox();
+
+	m_autoMode = false;
 }
 
-void NCEditLine::Commit()
+void NCEditLine::UpdateHistory()
 {
-    HistCommit(_group, GetText().data());
-	_histList = 0;
+	HistCommit( m_fieldName, GetText().data() );
 }
-

--- a/src/nceditline.cpp
+++ b/src/nceditline.cpp
@@ -5,94 +5,15 @@
 */
 
 #include "nceditline.h"
-#include "wcm-config.h"
 #include "string-util.h"
 #include "unicode_lc.h"
+#include "nchistory.h"
 
-
-#define MAX_FIELD_HISTORY_COUNT	50
-
-typedef ccollect<std::vector<unicode_t>> HistCollect;
-
-static cstrhash<clPtr<HistCollect>> g_histHash;
-
-
-inline bool HistoryCanSave()
-{
-	//return wcmConfig.systemSaveHistory;
-	return true;
-}
 
 inline bool AcEnabled()
 {
 	//return wcmConfig.systemAutoComplete;
 	return true;
-}
-
-HistCollect* HistGetList( const char* fieldName )
-{
-	if ( !fieldName || !fieldName[0] )
-	{
-		return nullptr;
-	}
-	
-	clPtr<HistCollect>* pp = g_histHash.exist( fieldName );
-	if ( pp && pp->ptr() )
-	{
-		return pp->ptr();
-	}
-	
-	return nullptr;
-}
-
-// Returns index of element with the specified name, or -1 if no such found
-int FindByName( HistCollect* pList, const unicode_t* name )
-{
-	for (int i = 0, count = pList->count(); i < count; i++)
-	{
-		if (unicode_is_equal( name, pList->get(i).data() ))
-		{
-			return i;
-		}
-	}
-	
-	return -1;
-}
-
-void AddFieldTextToHistory( const char* fieldName, const unicode_t* txt )
-{
-	if ( !HistoryCanSave() || !fieldName || !fieldName[0] || !txt || !txt[0] )
-	{
-		return;
-	}
-
-	std::vector<unicode_t> str = new_unicode_str( txt );
-
-	// get history collection for field
-	HistCollect* pList = HistGetList( fieldName );
-	if ( !pList)
-	{
-		clPtr<HistCollect> pUList = new HistCollect;
-		pList = pUList.ptr();
-		g_histHash[fieldName] = pUList;
-	}
-	
-	// check if item already exists in the list
-	const int index = FindByName( pList, str.data() );
-	if ( index != -1 )
-	{
-		// remove existing item
-		pList->del( index );
-	}
-	
-	// add item to the and of the list
-	pList->insert( 0, str );
-	
-	// limit number of elements in the list
-	while ( pList->count() > MAX_FIELD_HISTORY_COUNT )
-	{
-		pList->del( pList->count() - 1 );
-	}
 }
 
 static int uiClassNCEditLine = GetUiID( "NCEditLine" );
@@ -109,12 +30,12 @@ NCEditLine::NCEditLine( const char* fieldName, int nId, Win* parent, const unico
 				  rect )
 	, m_fieldName( fieldName )
 {
-	HistCollect* pList = HistGetList( m_fieldName );
+	HistCollect* pList = GetFieldHistCollect( m_fieldName );
 	if ( pList )
 	{
-		for ( int i = 0, count = pList->count(); i < count; i++ )
+		for ( int i = 0, count = pList->size(); i < count; i++ )
 		{
-			const unicode_t* u = pList->get( i ).data();
+			const unicode_t* u = pList->at( i ).data();
 			if ( u )
 			{
 				Append( u );

--- a/src/nceditline.h
+++ b/src/nceditline.h
@@ -18,18 +18,12 @@ class NCEditLine : public ComboBox
 {
 private:
 	const char* m_fieldName;
-	bool m_autoMode;
-
-	//void SetCBList(const unicode_t* txt);
-	//void Clear();
-
+	
 public:
 	NCEditLine( const char* fieldName, int nId, Win* parent, const unicode_t* txt,
 		int cols, int rows, bool up, bool frame3d, bool nofocusframe, crect* rect = 0 );
 
-	virtual ~NCEditLine()
-	{
-	}
+	virtual ~NCEditLine() {}
 
 	bool Command( int id, int subId, Win* win, void* d ) override;
 
@@ -37,7 +31,5 @@ public:
 
 	bool OnOpenBox() override;
 
-	void OnCloseBox() override;
-
-	void UpdateHistory();
+	void AddCurrentTextToHistory();
 };

--- a/src/nceditline.h
+++ b/src/nceditline.h
@@ -10,36 +10,34 @@
 
 using namespace wal;
 
-typedef ccollect<std::vector<unicode_t>> HistCollect;
 
-
-// editline with history and autocomplete
-class NCEditLine: public ComboBox {
-
+/**
+* Edit line controll with history and autocomplete support.
+*/
+class NCEditLine : public ComboBox
+{
 private:
-    clPtr<HistCollect> _histList;
-	const char *_group;
-	bool _autoMode;
-	void SetCBList(const unicode_t *txt);
-	void LoadHistoryList();
+	const char* m_fieldName;
+	bool m_autoMode;
+
+	//void SetCBList(const unicode_t* txt);
+	//void Clear();
 
 public:
-	NCEditLine(const char *acGroup, int nId, Win *parent, const unicode_t *txt, int cols, int rows, bool up, bool frame3d, bool nofocusframe, crect *rect = 0);
-	
-    virtual ~NCEditLine() {}
+	NCEditLine( const char* fieldName, int nId, Win* parent, const unicode_t* txt,
+		int cols, int rows, bool up, bool frame3d, bool nofocusframe, crect* rect = 0 );
 
-    virtual bool Command(int id, int subId, Win *win, void *d);
-	
-    virtual int UiGetClassId();
-	
-    virtual bool OnOpenBox();
-	
-    virtual void OnCloseBox();
-	
-    void Clear();
+	virtual ~NCEditLine()
+	{
+	}
 
-    void Commit();
+	bool Command( int id, int subId, Win* win, void* d ) override;
+
+	int UiGetClassId() override;
+
+	bool OnOpenBox() override;
+
+	void OnCloseBox() override;
+
+	void UpdateHistory();
 };
-
-
-HistCollect* HistGetList(const char *histGroup);

--- a/src/nceditline.h
+++ b/src/nceditline.h
@@ -12,24 +12,24 @@ using namespace wal;
 
 
 /**
-* Edit line controll with history and autocomplete support.
-*/
-class NCEditLine : public ComboBox
+ * Edit line controll with history and autocomplete support.
+ */
+class clNCEditLine : public ComboBox
 {
 private:
-	const char* m_fieldName;
+	const char* m_FieldName;
 	
 public:
-	NCEditLine( const char* fieldName, int nId, Win* parent, const unicode_t* txt,
-		int cols, int rows, bool up, bool frame3d, bool nofocusframe, crect* rect = 0 );
+	clNCEditLine( const char* FieldName, int Id, Win* Parent, const unicode_t* Txt,
+		int Cols, int Rows, bool Up, bool Frame3d, bool NoFocusFrame, crect* Rect = 0 );
 
-	virtual ~NCEditLine() {}
+	virtual ~clNCEditLine() {}
 
-	bool Command( int id, int subId, Win* win, void* d ) override;
+	virtual bool Command( int Id, int SubId, Win* Win, void* Data ) override;
 
-	int UiGetClassId() override;
+	virtual int UiGetClassId() override;
 
-	bool OnOpenBox() override;
+	virtual bool OnOpenBox() override;
 
 	void AddCurrentTextToHistory();
 };

--- a/src/nceditline.h
+++ b/src/nceditline.h
@@ -1,0 +1,45 @@
+/*
+* Part of Wal Commander GitHub Edition
+* https://github.com/corporateshark/WalCommander
+* walcommander@linderdaum.com
+*/
+
+#pragma once
+
+#include <swl.h>
+
+using namespace wal;
+
+typedef ccollect<std::vector<unicode_t>> HistCollect;
+
+
+// editline with history and autocomplete
+class NCEditLine: public ComboBox {
+
+private:
+    clPtr<HistCollect> _histList;
+	const char *_group;
+	bool _autoMode;
+	void SetCBList(const unicode_t *txt);
+	void LoadHistoryList();
+
+public:
+	NCEditLine(const char *acGroup, int nId, Win *parent, const unicode_t *txt, int cols, int rows, bool up, bool frame3d, bool nofocusframe, crect *rect = 0);
+	
+    virtual ~NCEditLine() {}
+
+    virtual bool Command(int id, int subId, Win *win, void *d);
+	
+    virtual int UiGetClassId();
+	
+    virtual bool OnOpenBox();
+	
+    virtual void OnCloseBox();
+	
+    void Clear();
+
+    void Commit();
+};
+
+
+HistCollect* HistGetList(const char *histGroup);

--- a/src/nceditline.h
+++ b/src/nceditline.h
@@ -17,6 +17,7 @@ using namespace wal;
 class clNCEditLine : public ComboBox
 {
 private:
+	std::vector<unicode_t> m_Prefix;
 	const char* m_FieldName;
 	
 public:
@@ -30,6 +31,11 @@ public:
 	virtual int UiGetClassId() override;
 
 	virtual bool OnOpenBox() override;
+	
+	virtual void OnItemChanged( int ItemIndex ) override;
 
 	void AddCurrentTextToHistory();
+	
+private:
+	void InitBox();
 };

--- a/src/nchistory.cpp
+++ b/src/nchistory.cpp
@@ -5,12 +5,25 @@
  */
 
 #include "nchistory.h"
+#include "wcm-config.h"
 
 
 #define MAX_FIELD_HISTORY_COUNT	50
 
+static const char fieldHistSection[] = "FieldsHistory";
+
 static cstrhash<HistCollect> g_fieldHistHash;
 
+
+void LoadFieldsHistory()
+{
+	
+}
+
+void SaveFieldsHistory()
+{
+	
+}
 
 inline bool HistoryCanSave()
 {

--- a/src/nchistory.cpp
+++ b/src/nchistory.cpp
@@ -12,7 +12,7 @@
 
 static const char fieldHistSection[] = "FieldsHistory";
 
-static cstrhash<HistCollect> g_fieldHistHash;
+static cstrhash<HistCollect_t> g_FieldsHistHash;
 
 
 void LoadFieldsHistory()
@@ -20,23 +20,23 @@ void LoadFieldsHistory()
 	IniHash iniHash;
 	IniHashLoad( iniHash, fieldHistSection );
 
-	g_fieldHistHash.clear();
-	std::vector<const char*> secList = iniHash.Keys();
-	char name[64];
+	g_FieldsHistHash.clear();
+	std::vector<const char*> SecList = iniHash.Keys();
+	char Name[64];
 	
-	for ( int i = 0, sectCount = secList.size(); i < sectCount; i++ )
+	for ( int i = 0, count = SecList.size(); i < count; i++ )
 	{
-		const char* section = secList[i];
-		HistCollect& list = g_fieldHistHash.get( section );
+		const char* Section = SecList[i];
+		HistCollect_t& List = g_FieldsHistHash.get( Section );
 
 		for ( int j = 0; j < MAX_FIELD_HISTORY_COUNT; j++ )
 		{
-			Lsnprintf( name, sizeof( name ), "v%i", j );
-			const char* value = iniHash.GetStrValue( section, name, nullptr );
-			if ( value )
+			Lsnprintf( Name, sizeof( Name ), "v%i", j );
+			const char* Value = iniHash.GetStrValue( Section, Name, nullptr );
+			if ( Value )
 			{
-				std::vector<unicode_t> str = utf8_to_unicode( value );
-				list.push_back( str );
+				std::vector<unicode_t> Str = utf8_to_unicode( Value );
+				List.push_back( Str );
 			}
 		}
 	}
@@ -45,47 +45,47 @@ void LoadFieldsHistory()
 void SaveFieldsHistory()
 {
 	IniHash iniHash;
-	std::vector<const char*> secList = g_fieldHistHash.keys();
-	char name[64];
+	std::vector<const char*> SecList = g_FieldsHistHash.keys();
+	char Name[64];
 
-	for ( int i = 0, sectCount = secList.size(); i < sectCount; i++ )
+	for ( int i = 0, SecCount = SecList.size(); i < SecCount; i++ )
 	{
-		const char* section = secList[i];
-		HistCollect* pList = g_fieldHistHash.exist( section );
-		if ( !pList )
+		const char* Section = SecList[i];
+		HistCollect_t* List = g_FieldsHistHash.exist( Section );
+		if ( !List )
 		{
 			continue;
 		}
 
-		for ( int j = 0, valCount = pList->size(); j < valCount; j++ )
+		for ( int j = 0, ValCount = List->size(); j < ValCount; j++ )
 		{
-			Lsnprintf( name, sizeof( name ), "v%i", j );
-			std::string val = unicode_to_utf8_string( pList->at(j).data() );
+			Lsnprintf( Name, sizeof( Name ), "v%i", j );
+			std::string Val = unicode_to_utf8_string( List->at(j).data() );
 			
-			iniHash.SetStrValue( section, name, val.c_str());
+			iniHash.SetStrValue( Section, Name, Val.c_str());
 		}
 	}
 
 	IniHashSave( iniHash, fieldHistSection );
 }
 
-HistCollect* GetFieldHistCollect( const char* fieldName )
+HistCollect_t* GetFieldHistCollect( const char* FieldName )
 {
-	if ( !fieldName || !fieldName[0] )
+	if ( !FieldName || !FieldName[0] )
 	{
 		return nullptr;
 	}
 	
-	HistCollect* pList = g_fieldHistHash.exist( fieldName );
-	return pList ? pList : nullptr;
+	HistCollect_t* List = g_FieldsHistHash.exist( FieldName );
+	return List ? List : nullptr;
 }
 
 // Returns index of element with the specified text, or -1 if no such found
-int FindHistElement( HistCollect* pList, const unicode_t* text )
+int FindHistElement( HistCollect_t* List, const unicode_t* Text )
 {
-	for (int i = 0, count = pList->size(); i < count; i++)
+	for (int i = 0, count = List->size(); i < count; i++)
 	{
-		if (unicode_is_equal( text, pList->at(i).data() ))
+		if (unicode_is_equal( Text, List->at(i).data() ))
 		{
 			return i;
 		}
@@ -94,32 +94,32 @@ int FindHistElement( HistCollect* pList, const unicode_t* text )
 	return -1;
 }
 
-void AddFieldTextToHistory( const char* fieldName, const unicode_t* txt )
+void AddFieldTextToHistory( const char* FieldName, const unicode_t* Txt )
 {
-	if ( !fieldName || !fieldName[0] || !txt || !txt[0] )
+	if ( !FieldName || !FieldName[0] || !Txt || !Txt[0] )
 	{
 		return;
 	}
 	
-	std::vector<unicode_t> str = new_unicode_str( txt );
+	std::vector<unicode_t> Str = new_unicode_str( Txt );
 	
-	HistCollect& list = g_fieldHistHash.get( fieldName );
+	HistCollect_t& List = g_FieldsHistHash.get( FieldName );
 	
 	// check if item already exists in the list
-	const int index = FindHistElement( &list, str.data() );
-	if ( index != -1 )
+	const int Index = FindHistElement( &List, Str.data() );
+	if ( Index != -1 )
 	{
 		// remove existing item
-		list.erase( list.begin() + index );
+		List.erase( List.begin() + Index );
 	}
 	
 	// add item to the begining of the list
-	list.insert( list.begin(), str );
+	List.insert( List.begin(), Str );
 	
 	// limit number of elements in the list
-	while ( list.size() > MAX_FIELD_HISTORY_COUNT )
+	while ( List.size() > MAX_FIELD_HISTORY_COUNT )
 	{
-		list.erase( list.end() );
+		List.erase( List.end() );
 	}
 }
 

--- a/src/nchistory.cpp
+++ b/src/nchistory.cpp
@@ -69,12 +69,6 @@ void SaveFieldsHistory()
 	IniHashSave( iniHash, fieldHistSection );
 }
 
-inline bool HistoryCanSave()
-{
-	//return wcmConfig.systemSaveHistory;
-	return true;
-}
-
 HistCollect* GetFieldHistCollect( const char* fieldName )
 {
 	if ( !fieldName || !fieldName[0] )
@@ -102,7 +96,7 @@ int FindHistElement( HistCollect* pList, const unicode_t* text )
 
 void AddFieldTextToHistory( const char* fieldName, const unicode_t* txt )
 {
-	if ( !HistoryCanSave() || !fieldName || !fieldName[0] || !txt || !txt[0] )
+	if ( !fieldName || !fieldName[0] || !txt || !txt[0] )
 	{
 		return;
 	}

--- a/src/nchistory.h
+++ b/src/nchistory.h
@@ -8,8 +8,8 @@
 
 #include <wal.h>
 
-
 using namespace wal;
+
 
 #define EDIT_FIELD_SEARCH_TEXT			"search-text"
 #define EDIT_FIELD_SEARCH_REPLACE_TEXT	"search-replace-text"
@@ -28,15 +28,16 @@ using namespace wal;
 #define EDIT_FIELD_SMB_DOMAIN				"smb-domain"
 #define EDIT_FIELD_SMB_USER				"smb-user"
 
-typedef std::vector<std::vector<unicode_t>> HistCollect;
+
+typedef std::vector<std::vector<unicode_t>> HistCollect_t;
 
 void LoadFieldsHistory();
 
 void SaveFieldsHistory();
 
-HistCollect* GetFieldHistCollect( const char* fieldName );
+HistCollect_t* GetFieldHistCollect( const char* FieldName );
 
-void AddFieldTextToHistory( const char* fieldName, const unicode_t* txt );
+void AddFieldTextToHistory( const char* FieldName, const unicode_t* Txt );
 
 
 class NCHistory
@@ -58,6 +59,6 @@ public:
 	void ResetToLast() { m_Current = -1; }
 
 private:
-	HistCollect m_List;
+	HistCollect_t m_List;
 	int m_Current;
 };

--- a/src/nchistory.h
+++ b/src/nchistory.h
@@ -8,7 +8,15 @@
 
 #include <wal.h>
 
+
 using namespace wal;
+
+typedef std::vector<std::vector<unicode_t>> HistCollect;
+
+HistCollect* GetFieldHistCollect( const char* fieldName );
+
+void AddFieldTextToHistory( const char* fieldName, const unicode_t* txt );
+
 
 class NCHistory
 {
@@ -29,6 +37,6 @@ public:
 	void ResetToLast() { m_Current = -1; }
 
 private:
-	std::vector< std::vector<unicode_t> > m_List;
+	HistCollect m_List;
 	int m_Current;
 };

--- a/src/nchistory.h
+++ b/src/nchistory.h
@@ -13,6 +13,10 @@ using namespace wal;
 
 typedef std::vector<std::vector<unicode_t>> HistCollect;
 
+void LoadFieldsHistory();
+
+void SaveFieldsHistory();
+
 HistCollect* GetFieldHistCollect( const char* fieldName );
 
 void AddFieldTextToHistory( const char* fieldName, const unicode_t* txt );

--- a/src/nchistory.h
+++ b/src/nchistory.h
@@ -11,6 +11,23 @@
 
 using namespace wal;
 
+#define EDIT_FIELD_SEARCH_TEXT			"search-text"
+#define EDIT_FIELD_SEARCH_REPLACE_TEXT	"search-replace-text"
+
+#define EDIT_FIELD_APPLY_COMMAND			"apply-command"
+#define EDIT_FIELD_MAKE_FOLDER			"make-folder"
+#define EDIT_FIELD_FILE_MASK				"file-mask"
+#define EDIT_FIELD_FILE_EDIT				"file-edit"
+#define EDIT_FIELD_FILE_TARGET			"file-target"
+
+#define EDIT_FIELD_FTP_SERVER				"ftp-server"
+#define EDIT_FIELD_FTP_USER				"ftp-user"
+#define EDIT_FIELD_SFTP_SERVER			"sftp-server"
+#define EDIT_FIELD_SFTP_USER				"sftp-user"
+#define EDIT_FIELD_SMB_SERVER				"smb-server"
+#define EDIT_FIELD_SMB_DOMAIN				"smb-domain"
+#define EDIT_FIELD_SMB_USER				"smb-user"
+
 typedef std::vector<std::vector<unicode_t>> HistCollect;
 
 void LoadFieldsHistory();

--- a/src/ncwin.cpp
+++ b/src/ncwin.cpp
@@ -1649,7 +1649,7 @@ void NCWin::ApplyCommand()
 {
 	if ( _mode != PANEL ) { return; }
 
-	std::vector<unicode_t> command = InputStringDialog( this, utf8_to_unicode( _LT( "Apply command to the selected files" ) ).data() );
+	std::vector<unicode_t> command = InputStringDialog( EDIT_FIELD_APPLY_COMMAND, this, utf8_to_unicode( _LT( "Apply command to the selected files" ) ).data() );
 
 	ApplyCommandToList( command, _panel->GetSelectedList(), _panel );
 }
@@ -1662,7 +1662,7 @@ void NCWin::CreateDirectory()
 
 	try
 	{
-		dir = InputStringDialog( this, utf8_to_unicode( _LT( "Create new directory" ) ).data() );
+		dir = InputStringDialog( EDIT_FIELD_MAKE_FOLDER, this, utf8_to_unicode( _LT( "Create new directory" ) ).data() );
 
 		if ( !dir.data() ) { return; }
 
@@ -1848,7 +1848,7 @@ void NCWin::Edit( bool enterFileName, bool Secondary )
 		if ( enterFileName )
 		{
 			static std::vector<unicode_t> savedUri;
-			std::vector<unicode_t> uri = InputStringDialog( this, utf8_to_unicode( _LT( "File to edit" ) ).data(), savedUri.data() );
+			std::vector<unicode_t> uri = InputStringDialog( EDIT_FIELD_FILE_EDIT, this, utf8_to_unicode( _LT( "File to edit" ) ).data(), savedUri.data() );
 
 			if ( !uri.data() ) { return; }
 
@@ -2160,7 +2160,7 @@ void NCWin::Copy( bool shift )
 		pCaption = _LT("Copy file under cursor to:");
 	}
 
-	std::vector<unicode_t> str = InputStringDialog(this, utf8_to_unicode(pCaption).data(),
+	std::vector<unicode_t> str = InputStringDialog( EDIT_FIELD_FILE_TARGET, this, utf8_to_unicode( pCaption ).data(),
 	                                                 shift ? _panel->GetCurrentFileName() : uri.GetUnicode() );
 
 	if ( !str.data() || !str[0] ) { return; }
@@ -2277,7 +2277,7 @@ void NCWin::Move( bool shift )
 		pCaption = _LT("Move file under cursor to:");
 	}
 
-	std::vector<unicode_t> str = InputStringDialog(this, utf8_to_unicode(pCaption).data(),
+	std::vector<unicode_t> str = InputStringDialog( EDIT_FIELD_FILE_TARGET, this, utf8_to_unicode( pCaption ).data(),
 	                                                 shift ? _panel->GetCurrentFileName() : uri.GetUnicode() );
 
 	if ( !str.data() || !str[0] ) { return; }
@@ -2326,7 +2326,8 @@ void NCWin::Mark( bool enable )
 {
 	if ( _mode != PANEL ) { return; }
 
-	std::vector<unicode_t> str =  InputStringDialog( this, utf8_to_unicode( _LT( enable ? "Select" : "Deselect" ) ).data(), utf8_to_unicode( "*" ).data() );
+	std::vector<unicode_t> str = InputStringDialog( EDIT_FIELD_FILE_MASK, this, utf8_to_unicode( _LT( enable ? "Select" : "Deselect" ) ).data(),
+																	utf8_to_unicode( "*" ).data() );
 
 	if ( !str.data() || !str[0] ) { return; }
 
@@ -2529,7 +2530,7 @@ bool NCWin::EditSave( bool saveAs )
 		if ( saveAs )
 		{
 			static std::vector<unicode_t> savedUri;
-			std::vector<unicode_t> uri = InputStringDialog( this, utf8_to_unicode( _LT( "Save file as ..." ) ).data(), savedUri.data() );
+			std::vector<unicode_t> uri = InputStringDialog( EDIT_FIELD_FILE_EDIT, this, utf8_to_unicode( _LT( "Save file as ..." ) ).data(), savedUri.data() );
 
 			if ( !uri.data() ) { return false; }
 

--- a/src/ncwin.cpp
+++ b/src/ncwin.cpp
@@ -1647,27 +1647,44 @@ void NCWin::ApplyCommandToList( const std::vector<unicode_t>& cmd, clPtr<FSList>
 
 void NCWin::ApplyCommand()
 {
-	if ( _mode != PANEL ) { return; }
+	if ( _mode != PANEL )
+	{
+		return;
+	}
 
-	std::vector<unicode_t> command = InputStringDialog( EDIT_FIELD_APPLY_COMMAND, this, utf8_to_unicode( _LT( "Apply command to the selected files" ) ).data() );
+	static std::vector<unicode_t> command;
+   std::vector<unicode_t> str = InputStringDialog( EDIT_FIELD_APPLY_COMMAND, this,
+																  utf8_to_unicode( _LT( "Apply command to the selected files" ) ).data(),
+																  command.data() );
+	if ( !str.data() )
+	{
+		return;
+	}
 
+	command = str;
 	ApplyCommandToList( command, _panel->GetSelectedList(), _panel );
 }
 
 void NCWin::CreateDirectory()
 {
-	if ( _mode != PANEL ) { return; }
+	if ( _mode != PANEL )
+	{
+		return;
+	}
 
-	std::vector<unicode_t> dir;
-
+	static std::vector<unicode_t> dir;
 	try
 	{
-		dir = InputStringDialog( EDIT_FIELD_MAKE_FOLDER, this, utf8_to_unicode( _LT( "Create new directory" ) ).data() );
+		std::vector<unicode_t> str = InputStringDialog( EDIT_FIELD_MAKE_FOLDER, this,
+																	  utf8_to_unicode( _LT( "Create new directory" ) ).data(), dir.data() );
+		if ( !str.data() )
+		{
+			return;
+		}
 
-		if ( !dir.data() ) { return; }
-
+		dir = str;
 		const std::vector<clPtr<FS>> checkFS = { _panel->GetFSPtr(), GetOtherPanel()->GetFSPtr() };
-
+		
 		FSPath path = _panel->GetPath();
 		clPtr<FS> fs = ParzeURI( dir.data(), path, checkFS );
 
@@ -1675,8 +1692,8 @@ void NCWin::CreateDirectory()
 		{
 			char buf[4096];
 			FSString name = dir.data();
-			Lsnprintf( buf, sizeof( buf ), _LT( "can`t create directory:%s\n" ), name.GetUtf8() );
-			NCMessageBox( this, "CD", buf, true );
+			Lsnprintf( buf, sizeof( buf ), _LT( "Can't create directory: '%s'\n" ), name.GetUtf8() );
+			NCMessageBox( this, "Create directory", buf, true );
 			return;
 		}
 
@@ -2324,13 +2341,23 @@ void NCWin::Move( bool shift )
 
 void NCWin::Mark( bool enable )
 {
-	if ( _mode != PANEL ) { return; }
+	if ( _mode != PANEL )
+	{
+		return;
+	}
 
-	std::vector<unicode_t> str = InputStringDialog( EDIT_FIELD_FILE_MASK, this, utf8_to_unicode( _LT( enable ? "Select" : "Deselect" ) ).data(),
-																	utf8_to_unicode( "*" ).data() );
+	static std::vector<unicode_t> mask = utf8_to_unicode( "*" );
+	
+	std::vector<unicode_t> str = InputStringDialog( EDIT_FIELD_FILE_MASK, this,
+																  utf8_to_unicode( _LT( enable ? "Select" : "Deselect" ) ).data(),
+																  mask.data() );
 
-	if ( !str.data() || !str[0] ) { return; }
+	if ( !str.data() || !str[0] )
+	{
+		return;
+	}
 
+	mask = str;
 	_panel->Mark( str.data(), enable );
 }
 

--- a/src/panel.cpp
+++ b/src/panel.cpp
@@ -670,10 +670,9 @@ bool PanelWin::Broadcast( int id, int subId, Win* win, void* data )
 	return false;
 }
 
-
-#define VLINE_WIDTH (3)
-#define MIN_BRIEF_CHARS 12
-#define MIN_MEDIUM_CHARS 18
+static const int VLINE_WIDTH = 3;
+static const int MIN_BRIEF_CHARS = 12;
+static const int MIN_MEDIUM_CHARS = 18;
 
 void PanelWin::Check()
 {
@@ -1711,29 +1710,17 @@ void PanelWin::LoadPathStringSafe( const char* path )
 	//dbg_printf( "PanelWin::LoadPathStringSafe path=%s\n", path );
 	FSPath fspath;
 
-	clPtr<FS> fs = ParzeURI( utf8_to_unicode( path ).data(), fspath, {} );
+	auto UTF8Path = utf8_to_unicode( path );
+
+	clPtr<FS> fs = ParzeURI( UTF8Path.data(), fspath, {} );
 
 	this->LoadPath( fs, fspath, 0, 0, PanelWin::SET );
 }
 
 void PanelWin::LoadPath( clPtr<FS> fs, FSPath& paramPath, FSString* current, clPtr<cstrhash<bool, unicode_t> > selected, LOAD_TYPE lType )
 {
-//printf("LoadPath '%s'\n", paramPath.GetUtf8());
-
 	FSStat stat;
 	FSCInfo info;
-//	int err;
-
-//	if ( fs->Stat(paramPath, &stat, &err, &info) == -1 ) return;Retain
-	if (fs == 0)
-	{
-	//	paramPath.dbg_printf("PanelWin::LoadPath fs is null, paramPath=");
-	}
-	else
-	{
-		//dbg_printf("PanelWin::LoadPath() fsUri=%s current=%s ", (fs->Uri(paramPath)).GetUtf8(), current ? current->GetUtf8() : "null");
-		//paramPath.dbg_printf(", paramPath=");
-	}
 
 	try
 	{
@@ -1904,7 +1891,6 @@ void PanelWin::OperThreadStopped()
 	Invalidate();
 }
 
-
 void PanelWin::Reread( bool resetCurrent, const FSString& Name )
 {
 	clPtr<cstrhash<bool, unicode_t> > sHash = _list.GetSelectedHash();
@@ -1923,7 +1909,6 @@ void PanelWin::Reread( bool resetCurrent, const FSString& Name )
 
 	LoadPath( GetFSPtr(), GetPath(), StrPtr, sHash, RESET );
 }
-
 
 bool PanelWin::EventMouse( cevent_mouse* pEvent )
 {
@@ -2130,7 +2115,7 @@ bool PanelWin::DirUp()
 void PanelWin::DirEnter(bool OpenInExplorer)
 {
 	if ( _place.IsEmpty() ) { return; }
-
+	
 	if ( !HideDotsInDir() && !Current() )
 	{
 		if ( OpenInExplorer )
@@ -2147,7 +2132,7 @@ void PanelWin::DirEnter(bool OpenInExplorer)
 
 		return;
 	};
-
+	  
 	FSNode* node = GetCurrent();
 
 	if ( !node || !node->IsDir() ) { return; }
@@ -2156,23 +2141,23 @@ void PanelWin::DirEnter(bool OpenInExplorer)
 	int cs = node->Name().PrimaryCS();
 	p.Push( cs, node->Name().Get( cs ) );
 
-
 	clPtr<FS> fs = GetFSPtr();
-
+	
 	if ( fs.IsNull() ) { return; }
 
 #ifdef _WIN32
-
 	if ( fs->Type() == FS::WIN32NET )
 	{
+		
 		NETRESOURCEW* nr = node->_w32NetRes.Get();
 
 		if ( !nr || !nr->lpRemoteName ) { return; }
-
+		
 		if ( node->extType == FSNode::FILESHARE )
 		{
 			FSPath path;
-			clPtr<FS> newFs = ParzeURI( Utf16ToUnicode( nr->lpRemoteName ).data(), path, {} );
+			auto UnicodeRemoteName = Utf16ToUnicode( nr->lpRemoteName );
+			clPtr<FS> newFs = ParzeURI( UnicodeRemoteName.data(), path, {} );
 			LoadPath( newFs, path, nullptr, nullptr, PUSH );
 		}
 		else
@@ -2184,7 +2169,6 @@ void PanelWin::DirEnter(bool OpenInExplorer)
 
 		return;
 	}
-
 #endif
 
 	// for smb servers
@@ -2221,7 +2205,4 @@ void PanelWin::DirRoot()
 	p.PushStr( FSString() ); //у абсолютного пути всегда пустая строка в начале
 	LoadPath( GetFSPtr(), p, 0, 0, RESET );
 }
-
-
-PanelWin::~PanelWin() {}
 

--- a/src/panel.h
+++ b/src/panel.h
@@ -323,5 +323,4 @@ public:
 	virtual bool Command( int id, int subId, Win* win, void* data );
 	virtual bool Broadcast( int id, int subId, Win* win, void* data );
 	virtual void OnChangeStyles();
-	virtual ~PanelWin();
 };

--- a/src/search-dlg.cpp
+++ b/src/search-dlg.cpp
@@ -14,7 +14,7 @@ class SearchParamDialog: public NCVertDialog
 	Layout iL;
 public:
 	StaticLabel textLabel;
-	NCEditLine textEdit;
+	clNCEditLine textEdit;
 	SButton  caseButton;
 
 	SearchParamDialog( NCDialogParent* parent, const SearchAndReplaceParams* params );
@@ -98,8 +98,8 @@ class SearchFileParamDialog: public NCVertDialog
 public:
 	StaticLabel maskText;
 	StaticLabel textText;
-	NCEditLine maskEdit;
-	NCEditLine textEdit;
+	clNCEditLine maskEdit;
+	clNCEditLine textEdit;
 	SButton  caseButton;
 
 	SearchFileParamDialog( NCDialogParent* parent, SearchAndReplaceParams* params );
@@ -178,8 +178,8 @@ class ReplaceEditParamDialog: public NCVertDialog
 public:
 	StaticLabel fromText;
 	StaticLabel toText;
-	NCEditLine fromEdit;
-	NCEditLine toEdit;
+	clNCEditLine fromEdit;
+	clNCEditLine toEdit;
 	SButton  caseButton;
 
 	ReplaceEditParamDialog( NCDialogParent* parent, SearchAndReplaceParams* params );

--- a/src/search-dlg.cpp
+++ b/src/search-dlg.cpp
@@ -28,7 +28,7 @@ SearchParamDialog::SearchParamDialog( NCDialogParent* parent, const SearchAndRep
 	:  NCVertDialog( ::createDialogAsChild, 0, parent, utf8_to_unicode( _LT( "Search" ) ).data(), bListOkCancel ),
 	   iL( 16, 3 ),
 	   textLabel( 0, this, utf8_to_unicode( _LT( "&Search for:" ) ).data(), &textEdit ),
-		textEdit( "search-text", 0, this, 0, 50, 7, false, true, false ),
+		textEdit( EDIT_FIELD_SEARCH_TEXT, 0, this, 0, 50, 7, false, true, false ),
 	   caseButton( 0, this, utf8_to_unicode( _LT( "C&ase sensitive" ) ).data(), 0, params->m_CaseSensitive )
 
 {
@@ -113,8 +113,8 @@ SearchFileParamDialog::SearchFileParamDialog( NCDialogParent* parent, SearchAndR
 	   iL( 16, 3 ),
 	   maskText( 0, this, utf8_to_unicode( _LT( "File &mask:" ) ).data(), &maskEdit ),
 	   textText( 0, this, utf8_to_unicode( _LT( "&Text:" ) ).data(), &textEdit ),
-		maskEdit( "fsearch-mask", 0, this, 0, 50, 7, false, true, false ),
-		textEdit( "search-text", 0, this, 0, 50, 7, false, true, false ),
+		maskEdit( EDIT_FIELD_FILE_MASK, 0, this, 0, 50, 7, false, true, false ),
+		textEdit( EDIT_FIELD_SEARCH_TEXT, 0, this, 0, 50, 7, false, true, false ),
 	   caseButton( 0, this, utf8_to_unicode( _LT( "C&ase sensitive" ) ).data(), 0, params->m_CaseSensitive )
 {
 	if ( params->m_SearchMask.data() ) { maskEdit.SetText( params->m_SearchMask.data(), true ); }
@@ -193,8 +193,8 @@ ReplaceEditParamDialog::ReplaceEditParamDialog( NCDialogParent* parent, SearchAn
 	   iL( 16, 3 ),
 	   fromText( 0, this, utf8_to_unicode( _LT( "&Search for:" ) ).data(), &fromEdit ),
 	   toText( 0, this, utf8_to_unicode( _LT( "&Replace with:" ) ).data(), &toEdit ),
-		fromEdit( "search-text", 0, this, 0, 50, 7, false, true, false ),
-		toEdit( "replace-text", 0, this, 0, 50, 7, false, true, false ),
+		fromEdit( EDIT_FIELD_SEARCH_TEXT, 0, this, 0, 50, 7, false, true, false ),
+		toEdit( EDIT_FIELD_SEARCH_REPLACE_TEXT, 0, this, 0, 50, 7, false, true, false ),
 	   caseButton( 0, this, utf8_to_unicode( _LT( "C&ase sensitive" ) ).data(), 0, params->m_CaseSensitive )
 {
 	if ( params->m_SearchText.data() ) { fromEdit.SetText( params->m_SearchText.data(), true ); }

--- a/src/search-dlg.cpp
+++ b/src/search-dlg.cpp
@@ -7,6 +7,7 @@
 #include "ncdialogs.h"
 #include "search-dlg.h"
 #include "ltext.h"
+#include "nceditline.h"
 
 class SearchParamDialog: public NCVertDialog
 {
@@ -96,8 +97,8 @@ class SearchFileParamDialog: public NCVertDialog
 public:
 	StaticLabel maskText;
 	StaticLabel textText;
-	EditLine maskEdit;
-	EditLine textEdit;
+	NCEditLine maskEdit;
+	NCEditLine textEdit;
 	SButton  caseButton;
 
 	SearchFileParamDialog( NCDialogParent* parent, SearchAndReplaceParams* params );
@@ -111,8 +112,10 @@ SearchFileParamDialog::SearchFileParamDialog( NCDialogParent* parent, SearchAndR
 	   iL( 16, 3 ),
 	   maskText( 0, this, utf8_to_unicode( _LT( "File &mask:" ) ).data(), &maskEdit ),
 	   textText( 0, this, utf8_to_unicode( _LT( "&Text:" ) ).data(), &textEdit ),
-	   maskEdit( 0, this, 0, 0, 50 ),
-	   textEdit ( 0, this, 0, 0, 50 ),
+       //maskEdit(0, this, 0, 0, 50),
+       maskEdit( "fsearch-mask", 0, this, 0, 50, 7, false, true, false ),
+       //textEdit(0, this, 0, 0, 50),
+       textEdit("fsearch-text", 0, this, 0, 50, 7, false, true, false),
 	   caseButton( 0, this, utf8_to_unicode( _LT( "C&ase sensitive" ) ).data(), 0, params->m_CaseSensitive )
 {
 	if ( params->m_SearchMask.data() ) { maskEdit.SetText( params->m_SearchMask.data(), true ); }

--- a/src/search-dlg.cpp
+++ b/src/search-dlg.cpp
@@ -14,7 +14,7 @@ class SearchParamDialog: public NCVertDialog
 	Layout iL;
 public:
 	StaticLabel textLabel;
-	EditLine textEdit;
+	NCEditLine textEdit;
 	SButton  caseButton;
 
 	SearchParamDialog( NCDialogParent* parent, const SearchAndReplaceParams* params );
@@ -28,7 +28,7 @@ SearchParamDialog::SearchParamDialog( NCDialogParent* parent, const SearchAndRep
 	:  NCVertDialog( ::createDialogAsChild, 0, parent, utf8_to_unicode( _LT( "Search" ) ).data(), bListOkCancel ),
 	   iL( 16, 3 ),
 	   textLabel( 0, this, utf8_to_unicode( _LT( "&Search for:" ) ).data(), &textEdit ),
-	   textEdit( 0, this, 0, 0, 50 ),
+		textEdit( "search-text", 0, this, 0, 50, 7, false, true, false ),
 	   caseButton( 0, this, utf8_to_unicode( _LT( "C&ase sensitive" ) ).data(), 0, params->m_CaseSensitive )
 
 {
@@ -82,6 +82,7 @@ bool DoSearchDialog( NCDialogParent* parent, SearchAndReplaceParams* params )
 	{
 		params->m_CaseSensitive = dlg.caseButton.IsSet();
 		params->m_SearchText = dlg.textEdit.GetText();
+		dlg.textEdit.AddCurrentTextToHistory();
 		return true;
 	}
 
@@ -112,10 +113,8 @@ SearchFileParamDialog::SearchFileParamDialog( NCDialogParent* parent, SearchAndR
 	   iL( 16, 3 ),
 	   maskText( 0, this, utf8_to_unicode( _LT( "File &mask:" ) ).data(), &maskEdit ),
 	   textText( 0, this, utf8_to_unicode( _LT( "&Text:" ) ).data(), &textEdit ),
-       //maskEdit(0, this, 0, 0, 50),
-       maskEdit( "fsearch-mask", 0, this, 0, 50, 7, false, true, false ),
-       //textEdit(0, this, 0, 0, 50),
-       textEdit("fsearch-text", 0, this, 0, 50, 7, false, true, false),
+		maskEdit( "fsearch-mask", 0, this, 0, 50, 7, false, true, false ),
+		textEdit( "search-text", 0, this, 0, 50, 7, false, true, false ),
 	   caseButton( 0, this, utf8_to_unicode( _LT( "C&ase sensitive" ) ).data(), 0, params->m_CaseSensitive )
 {
 	if ( params->m_SearchMask.data() ) { maskEdit.SetText( params->m_SearchMask.data(), true ); }
@@ -158,8 +157,12 @@ bool DoFileSearchDialog( NCDialogParent* parent, SearchAndReplaceParams* params 
 	if ( dlg.DoModal() == CMD_OK )
 	{
 		params->m_CaseSensitive = dlg.caseButton.IsSet();
+		
 		params->m_SearchMask = dlg.maskEdit.GetText();
+		dlg.maskEdit.AddCurrentTextToHistory();
+		
 		params->m_SearchText = dlg.textEdit.GetText();
+		dlg.textEdit.AddCurrentTextToHistory();
 		return true;
 	}
 
@@ -175,8 +178,8 @@ class ReplaceEditParamDialog: public NCVertDialog
 public:
 	StaticLabel fromText;
 	StaticLabel toText;
-	EditLine fromEdit;
-	EditLine toEdit;
+	NCEditLine fromEdit;
+	NCEditLine toEdit;
 	SButton  caseButton;
 
 	ReplaceEditParamDialog( NCDialogParent* parent, SearchAndReplaceParams* params );
@@ -190,8 +193,8 @@ ReplaceEditParamDialog::ReplaceEditParamDialog( NCDialogParent* parent, SearchAn
 	   iL( 16, 3 ),
 	   fromText( 0, this, utf8_to_unicode( _LT( "&Search for:" ) ).data(), &fromEdit ),
 	   toText( 0, this, utf8_to_unicode( _LT( "&Replace with:" ) ).data(), &toEdit ),
-	   fromEdit ( 0, this, 0, 0, 50 ),
-	   toEdit   ( 0, this, 0, 0, 50 ),
+		fromEdit( "search-text", 0, this, 0, 50, 7, false, true, false ),
+		toEdit( "replace-text", 0, this, 0, 50, 7, false, true, false ),
 	   caseButton( 0, this, utf8_to_unicode( _LT( "C&ase sensitive" ) ).data(), 0, params->m_CaseSensitive )
 {
 	if ( params->m_SearchText.data() ) { fromEdit.SetText( params->m_SearchText.data(), true ); }
@@ -222,13 +225,14 @@ bool DoReplaceEditDialog( NCDialogParent* parent, SearchAndReplaceParams* params
 	if ( dlg.DoModal() == CMD_OK )
 	{
 		params->m_CaseSensitive = dlg.caseButton.IsSet();
+		
 		params->m_SearchText = dlg.fromEdit.GetText();
-		params->m_ReplaceTo =  dlg.toEdit.GetText();
+		dlg.fromEdit.AddCurrentTextToHistory();
+		
+		params->m_ReplaceTo = dlg.toEdit.GetText();
+		dlg.toEdit.AddCurrentTextToHistory();
 		return true;
 	}
 
 	return false;
 }
-
-
-

--- a/src/sftpdlg.cpp
+++ b/src/sftpdlg.cpp
@@ -56,8 +56,8 @@ SftpLogonDialog::SftpLogonDialog( NCDialogParent* parent, FSSftpParam& params )
 
 	   charset( params.charset ),
 
-		serverEdit( "sftp-server", 0, this, 0, 16, 7, false, true, false ),
-		userEdit( "sftp-user", 0, this, 0, 16, 7, false, true, false ),
+		serverEdit( EDIT_FIELD_SFTP_SERVER, 0, this, 0, 16, 7, false, true, false ),
+		userEdit( EDIT_FIELD_SFTP_USER, 0, this, 0, 16, 7, false, true, false ),
 	   portEdit ( 0, this, 0, 0, 7 ),
 
 	   charsetButton( 0, this, utf8_to_unicode( ">" ).data() , 1000 )

--- a/src/sftpdlg.cpp
+++ b/src/sftpdlg.cpp
@@ -30,8 +30,8 @@ public:
 
 	int charset;
 
-	NCEditLine serverEdit;
-	NCEditLine userEdit;
+	clNCEditLine serverEdit;
+	clNCEditLine userEdit;
 //	EditLine passwordEdit;
 	EditLine portEdit;
 	Button charsetButton;

--- a/src/smblogon.cpp
+++ b/src/smblogon.cpp
@@ -46,9 +46,9 @@ SmbLogonDialog::SmbLogonDialog( NCDialogParent* parent, FSSmbParam& params, bool
 	   domainText( 0, this, utf8_to_unicode( _LT( "&Domain:" ) ).data() ),
 	   userText( 0, this, utf8_to_unicode( _LT( "&Login:" ) ).data() ),
 	   passwordText( 0, this, utf8_to_unicode( _LT( "Pass&word:" ) ).data() ),
-		serverEdit( "smb-server", 0, this, 0, 16, 7, false, true, false ),
-		domainEdit( "smb-domain", 0, this, 0, 16, 7, false, true, false ),
-		userEdit( "smb-user", 0, this, 0, 16, 7, false, true, false ),
+		serverEdit( EDIT_FIELD_SMB_SERVER, 0, this, 0, 16, 7, false, true, false ),
+		domainEdit( EDIT_FIELD_SMB_DOMAIN, 0, this, 0, 16, 7, false, true, false ),
+		userEdit( EDIT_FIELD_SMB_USER, 0, this, 0, 16, 7, false, true, false ),
 	   passwordEdit   ( 0, this, 0, 0, 16 )
 {
 

--- a/src/smblogon.cpp
+++ b/src/smblogon.cpp
@@ -7,8 +7,9 @@
 #include "smblogon.h"
 
 #include "ncdialogs.h"
-#include "string-util.h" //для carray_cat
+#include "string-util.h"
 #include "ltext.h"
+#include "nceditline.h"
 
 #ifdef LIBSMBCLIENT_EXIST
 
@@ -25,9 +26,9 @@ public:
 	StaticLine userText;
 	StaticLine passwordText;
 
-	EditLine serverEdit;
-	EditLine domainEdit;
-	EditLine userEdit;
+	NCEditLine serverEdit;
+	NCEditLine domainEdit;
+	NCEditLine userEdit;
 	EditLine passwordEdit;
 
 	SmbLogonDialog( NCDialogParent* parent, FSSmbParam& params, bool enterServer );
@@ -45,9 +46,9 @@ SmbLogonDialog::SmbLogonDialog( NCDialogParent* parent, FSSmbParam& params, bool
 	   domainText( 0, this, utf8_to_unicode( _LT( "&Domain:" ) ).data() ),
 	   userText( 0, this, utf8_to_unicode( _LT( "&Login:" ) ).data() ),
 	   passwordText( 0, this, utf8_to_unicode( _LT( "Pass&word:" ) ).data() ),
-	   serverEdit  ( 0, this, 0, 0, 16 ),
-	   domainEdit  ( 0, this, 0, 0, 16 ),
-	   userEdit ( 0, this, 0, 0, 16 ),
+		serverEdit( "smb-server", 0, this, 0, 16, 7, false, true, false ),
+		domainEdit( "smb-domain", 0, this, 0, 16, 7, false, true, false ),
+		userEdit( "smb-user", 0, this, 0, 16, 7, false, true, false ),
 	   passwordEdit   ( 0, this, 0, 0, 16 )
 {
 
@@ -132,12 +133,17 @@ bool GetSmbLogon( NCDialogParent* parent, FSSmbParam& params, bool enterServer )
 	{
 		if ( enterServer )
 		{
-			Copy( params.server, unicode_to_utf8( dlg.serverEdit.GetText().data() ).data() , sizeof( params.server ) );
+			Copy( params.server, dlg.serverEdit.GetTextStr().data() , sizeof( params.server ) );
+			dlg.serverEdit.AddCurrentTextToHistory();
 		}
 
-		Copy( params.domain,  unicode_to_utf8( dlg.domainEdit.GetText().data() ).data() , sizeof( params.domain ) );
-		Copy( params.user, unicode_to_utf8( dlg.userEdit.GetText().data() ).data() , sizeof( params.user ) );
-		Copy( params.pass, unicode_to_utf8( dlg.passwordEdit.GetText().data() ).data() , sizeof( params.pass ) );
+		Copy( params.domain, dlg.domainEdit.GetTextStr().data() , sizeof( params.domain ) );
+		dlg.domainEdit.AddCurrentTextToHistory();
+		
+		Copy( params.user, dlg.userEdit.GetTextStr().data() , sizeof( params.user ) );
+		dlg.userEdit.AddCurrentTextToHistory();
+		
+		Copy( params.pass, dlg.passwordEdit.GetTextStr().data() , sizeof( params.pass ) );
 		params.isSet = true;
 		return true;
 	}

--- a/src/smblogon.cpp
+++ b/src/smblogon.cpp
@@ -26,9 +26,9 @@ public:
 	StaticLine userText;
 	StaticLine passwordText;
 
-	NCEditLine serverEdit;
-	NCEditLine domainEdit;
-	NCEditLine userEdit;
+	clNCEditLine serverEdit;
+	clNCEditLine domainEdit;
+	clNCEditLine userEdit;
 	EditLine passwordEdit;
 
 	SmbLogonDialog( NCDialogParent* parent, FSSmbParam& params, bool enterServer );

--- a/src/swl/swl_combobox.cpp
+++ b/src/swl/swl_combobox.cpp
@@ -9,7 +9,6 @@
 namespace wal
 {
 
-
 #define CB_BUTTONWIDTH 16
 
 	int uiClassComboBox = GetUiID( "ComboBox" );
@@ -18,7 +17,6 @@ namespace wal
 	{
 		return uiClassComboBox;
 	}
-
 
 	void ComboBox::MoveCurrent( int n )
 	{
@@ -88,7 +86,10 @@ namespace wal
 
 	void ComboBox::Clear()
 	{
-		if ( _box.ptr() ) { _box->Clear(); }
+		if ( _box.ptr() )
+		{
+			_box->Clear();
+		}
 
 		//CloseBox();
 		_list.clear();
@@ -97,7 +98,10 @@ namespace wal
 		{
 			_current = -1;
 
-			if ( IsVisible() ) { Invalidate(); }
+			if ( IsVisible() )
+			{
+				Invalidate();
+			}
 		}
 	}
 
@@ -129,7 +133,10 @@ namespace wal
 
 	void ComboBox::SetText( const unicode_t* txt, bool mark )
 	{
-		if ( this->_flags & READONLY ) { return; }
+		if ( this->_flags & READONLY )
+		{
+			return;
+		}
 
 		_edit.SetText( txt, mark );
 		MoveCurrent( -1 );
@@ -137,18 +144,23 @@ namespace wal
 
 	void ComboBox::InsertText( unicode_t t )
 	{
-		if ( this->_flags & READONLY ) { return; }
+		if ( this->_flags & READONLY )
+		{
+			return;
+		}
 
 		_edit.Insert( t );
 	}
 
 	void ComboBox::InsertText( const unicode_t* txt )
 	{
-		if ( this->_flags & READONLY ) { return; }
+		if ( this->_flags & READONLY )
+		{
+			return;
+		}
 
 		_edit.Insert( txt );
 	}
-
 
 	void* ComboBox::ItemData( int n )
 	{
@@ -159,8 +171,7 @@ namespace wal
 	{
 		if ( win == _box.ptr() && _box.ptr() )
 		{
-			int n = _box->GetCurrent();
-
+			const int n = _box->GetCurrent();
 			if ( n >= 0 && n < _list.count() && n != _current )
 			{
 				_current = n;
@@ -168,7 +179,7 @@ namespace wal
 				Command( CMD_ITEM_CHANGED, _current, this, 0 );
 			}
 
-			if ( id == CMD_ITEM_CLICK ) //иначе зациклится
+			if ( id == CMD_ITEM_CLICK )
 			{
 				CloseBox();
 			}
@@ -180,7 +191,10 @@ namespace wal
 		{
 			_current = -1;
 
-			if ( _box ) { _box->SetNoCurrent(); }
+			if ( _box )
+			{
+				_box->SetNoCurrent();
+			}
 
 			Command( CMD_ITEM_CHANGED, _current, this, 0 );
 			return true;
@@ -193,7 +207,10 @@ namespace wal
 	{
 		_edit.EventFocus( recv );
 
-		if ( !recv && _box.ptr() ) { CloseBox(); }
+		if ( !recv && _box.ptr() )
+		{
+			CloseBox();
+		}
 
 		Invalidate();
 		return true;
@@ -203,95 +220,61 @@ namespace wal
 	{
 		if ( pEvent->Type() == EV_KEYDOWN )
 		{
-			unsigned mod = pEvent->Mod();
-			unsigned fullKey = ( pEvent->Key() & 0xFFFF ) + ( mod << 16 );
+			const bool ctrl = (pEvent->Mod() & KM_CTRL) != 0;
 
-#define FC(key, mods) (((key)&0xFFFF) + ((mods)<<16))
-
-			switch ( fullKey )
+			switch ( pEvent->Key() )
 			{
-				case VK_ESCAPE:
-					if ( _box.ptr() )
-					{
-						CloseBox();
-						return true;
-					}
-
-					break;
-
-				case VK_RETURN:
-					if ( _box.ptr() )
-					{
-						CloseBox();
-						return _current >= 0;
-					}
-
-					break;
-
-				case FC( VK_UP, KM_SHIFT ):
-				case FC( VK_UP, KM_CTRL ):
-				case FC( VK_DOWN, KM_SHIFT ):
-				case FC( VK_DOWN, KM_CTRL ):
-					if ( _box.ptr() )
-					{
-						CloseBox();
-						return true;
-					}
-					else
-					{
-						OpenBox();
-						return true;
-					}
-
+			case VK_ESCAPE:
+				if ( IsBoxOpened() )
+				{
+					CloseBox();
 					return true;
+				}
 
+				break;
 
-				case VK_UP:
-					if ( _box.ptr() )
-					{
-						return _box->EventKey( pEvent );
-					}
-					else
-					{
-						if ( _current > 0 )
-						{
-							MoveCurrent( _current - 1 );
-							return true;
-						}
-					}
+			case VK_RETURN:
+				if ( IsBoxOpened() )
+				{
+					CloseBox();
+					return _current >= 0;
+				}
 
-					break;
+				break;
 
-				case VK_DOWN:
-					if ( _box.ptr() )
-					{
-						return _box->EventKey( pEvent );
-					}
-					else
-					{
-						if ( _current + 1 < _list.count() )
-						{
-							MoveCurrent( _current + 1 );
-							return true;
-						}
-					}
+			case VK_UP:
+				if ( ctrl && !IsBoxOpened() )
+				{
+					OpenBox();
+					return true;
+				}
 
-					break;
+				if ( IsBoxOpened() )
+				{
+					return _box->EventKey( pEvent );
+				}
 
-				case VK_NEXT:
-				case VK_PRIOR:
-					if ( _box.ptr() )
-					{
-						return _box->EventKey( pEvent );
-					}
+				break;
 
-					break;
+			case VK_DOWN:
+				if ( ctrl && !IsBoxOpened() )
+				{
+					OpenBox();
+					return true;
+				}
+
+				if ( IsBoxOpened() )
+				{
+					return _box->EventKey( pEvent );
+				}
+
+				break;
 			}
 
 			return _edit.EventKey( pEvent );
 		}
 
-		return false;
+		return Win::EventKey( pEvent );
 	}
 
 	bool ComboBox::OnOpenBox()
@@ -305,7 +288,10 @@ namespace wal
 
 	void ComboBox::RefreshBox()
 	{
-		if ( !_box.ptr() ) { return; }
+		if ( !_box.ptr() )
+		{
+			return;
+		}
 
 		_box->Clear();
 
@@ -319,30 +305,43 @@ namespace wal
 
 	void ComboBox::OpenBox()
 	{
-		if ( _box.ptr() ) { return; }
+		if ( _box.ptr() )
+		{
+			return;
+		}
 
-		if ( !OnOpenBox() ) { return; }
+		if ( !OnOpenBox() )
+		{
+			return;
+		}
 
-		_box = new TextList( Win::WT_POPUP, 0, 0, this, VListWin::SINGLE_SELECT,  VListWin::SINGLE_BORDER, 0 );
+		_box = new TextList( Win::WT_POPUP, 0, 0, this, VListWin::SINGLE_SELECT, VListWin::SINGLE_BORDER, 0 );
 
 		for ( int i = 0; i < _list.count(); i++ )
 		{
 			_box->Append( _list[i].text.data() );
 		}
 
-		if ( _current >= 0 ) { _box->MoveCurrent( _current ); }
+		if ( _current >= 0 )
+		{
+			_box->MoveCurrent( _current );
+		}
 
 		_box->SetHeightRange( LSRange( _rows, _rows, _rows ) );
 
 		int width = ClientRect().Width();
+		if ( width < 20 )
+		{
+			width = 20;
+		}
 
-		if ( width < 20 ) { width = 20; }
+		_box->Show( Win::SHOW_INACTIVE );
+		_box->Enable();
 
 		LSize ls;
 		_box->GetLSize( &ls );
 
 		crect rect = this->ScreenRect();
-
 		if ( _flags & MODE_UP )
 		{
 			rect.bottom = rect.top;
@@ -356,14 +355,15 @@ namespace wal
 		}
 
 		_box->Move( rect );
-		_box->Show( Win::SHOW_INACTIVE );
-		_box->Enable();
 		SetCapture( &captureSD );
 	}
 
 	void ComboBox::CloseBox()
 	{
-		if ( IsCaptured() ) { ReleaseCapture( &captureSD ); }
+		if ( IsCaptured() )
+		{
+			ReleaseCapture( &captureSD );
+		}
 
 		if ( _box.ptr() )
 		{
@@ -468,13 +468,10 @@ namespace wal
 			*/
 		}
 
-		DrawBorder( gc, cr, InFocus() && ( _flags & NOFOCUSFRAME ) == 0 ? UiGetColor( uiFocusFrameColor, 0, 0, 0 ) : ColorTone( UiGetColor( uiFrameColor, 0, 0, 0xFFFFFF ), -200 ) );
+		DrawBorder( gc, cr, InFocus() && ( _flags & NOFOCUSFRAME ) == 0 ? 
+            UiGetColor( uiFocusFrameColor, 0, 0, 0 ) : ColorTone( UiGetColor( uiFrameColor, 0, 0, 0xFFFFFF ), -200 ) );
 
 		SBCDrawButton( gc, _buttonRect, ( _flags & MODE_UP ) ? 4 : 5, bgColor, false );
 	}
-
-
-	ComboBox::~ComboBox() {}
-
 
 } //namespace wal

--- a/src/swl/swl_combobox.cpp
+++ b/src/swl/swl_combobox.cpp
@@ -18,17 +18,12 @@ namespace wal
 		return uiClassComboBox;
 	}
 
-	void ComboBox::MoveCurrent( int n )
+	void ComboBox::MoveCurrent( int n, bool notify )
 	{
 		int saved = _current;
 
 		if ( n < 0 )
 		{
-			if ( _flags & READONLY )
-			{
-				_edit.Clear();
-			}
-
 			_current = -1;
 
 			if ( _box.ptr() )
@@ -39,7 +34,6 @@ namespace wal
 		else if ( n < _list.count() )
 		{
 			_current = n;
-			_edit.SetText( _list[n].text.data() );
 
 			if ( _box.ptr() )
 			{
@@ -47,10 +41,27 @@ namespace wal
 			}
 		}
 
-		if ( saved != _current )
+		if ( saved != _current && notify )
 		{
-			Command( CMD_ITEM_CHANGED, _current, this, 0 );
+			OnItemChanged( _current );
 		}
+	}
+	
+	void ComboBox::OnItemChanged( int ItemIndex )
+	{
+		if ( ItemIndex < 0 )
+		{
+			if ( _flags & READONLY )
+			{
+				_edit.Clear();
+			}
+		}
+		else if ( ItemIndex < _list.count())
+		{
+			_edit.SetText( _list[ItemIndex].text.data() );
+		}
+		
+		Command( CMD_ITEM_CHANGED, ItemIndex, this, 0 );
 	}
 
 	void ComboBox::OnChangeStyles()
@@ -147,7 +158,7 @@ namespace wal
 		}
 
 		_edit.SetText( txt, mark );
-		MoveCurrent( -1 );
+		//MoveCurrent( -1, false );
 	}
 
 	void ComboBox::SetText( const std::string& utf8txt, bool mark )
@@ -188,8 +199,7 @@ namespace wal
 			if ( n >= 0 && n < _list.count() && n != _current )
 			{
 				_current = n;
-				_edit.SetText( ItemText( n ) );
-				Command( CMD_ITEM_CHANGED, _current, this, 0 );
+				OnItemChanged(_current);
 			}
 
 			if ( id == CMD_ITEM_CLICK )
@@ -209,7 +219,7 @@ namespace wal
 				_box->SetNoCurrent();
 			}
 
-			Command( CMD_ITEM_CHANGED, _current, this, 0 );
+			OnItemChanged(_current);
 			return true;
 		};
 
@@ -250,7 +260,6 @@ namespace wal
 				if ( IsBoxOpened() )
 				{
 					CloseBox();
-					return _current >= 0;
 				}
 
 				break;

--- a/src/swl/swl_combobox.cpp
+++ b/src/swl/swl_combobox.cpp
@@ -282,9 +282,15 @@ namespace wal
 				}
 
 				break;
+					
+			default:
+				if ( IsBoxOpened() && _box->EventKey( pEvent ) )
+				{
+					return true;
+				}
+				
+				return _edit.EventKey( pEvent );
 			}
-
-			return _edit.EventKey( pEvent );
 		}
 
 		return Win::EventKey( pEvent );

--- a/src/swl/swl_combobox.cpp
+++ b/src/swl/swl_combobox.cpp
@@ -72,6 +72,7 @@ namespace wal
 		_lo.AddWin( &_edit, 1, 1 );
 		_edit.SetClickFocusFlag( false );
 		_edit.SetTabFocusFlag( false );
+		_edit.SetShowSpaces( false );
 		_edit.Enable();
 		_edit.Show( SHOW_INACTIVE );
 		_lo.AddRect( &_buttonRect, 1, 2 );

--- a/src/swl/swl_combobox.cpp
+++ b/src/swl/swl_combobox.cpp
@@ -132,6 +132,13 @@ namespace wal
 		return _edit.GetText();
 	}
 
+	std::string ComboBox::GetTextStr() const
+	{
+		std::vector<unicode_t> V = GetText();
+
+		return unicode_to_utf8_string( V.data() );
+	}
+
 	void ComboBox::SetText( const unicode_t* txt, bool mark )
 	{
 		if ( this->_flags & READONLY )
@@ -141,6 +148,11 @@ namespace wal
 
 		_edit.SetText( txt, mark );
 		MoveCurrent( -1 );
+	}
+
+	void ComboBox::SetText( const std::string& utf8txt, bool mark )
+	{
+		SetText( utf8str_to_unicode( utf8txt ).data(), mark );
 	}
 
 	void ComboBox::InsertText( unicode_t t )

--- a/src/swl/swl_editline.cpp
+++ b/src/swl/swl_editline.cpp
@@ -680,6 +680,7 @@ namespace wal
 					if ( text.Cursor() == 0 ) { return true; }
 
 					text.Backspace( ctrl );
+					SendCommand( SCMD_EDITLINE_DELETED );
 					Changed();
 				}
 				break;
@@ -691,6 +692,7 @@ namespace wal
 					if ( text.Cursor() > text.Count() ) { return true; }
 
 					text.Del( ctrl );
+					SendCommand( SCMD_EDITLINE_DELETED );
 					Changed();
 				}
 				break;
@@ -767,6 +769,7 @@ namespace wal
 							SetText( oldtext.data(), false );
 						}
 
+						SendCommand( SCMD_EDITLINE_INSERTED );
 						Changed();
 					}
 					else { return false; }

--- a/src/swl/swl_winbase.h
+++ b/src/swl/swl_winbase.h
@@ -187,7 +187,9 @@ namespace wal
 	enum EditLineCmd
 	{
 		// subcommands of CMD_EDITLINE_INFO
-		SCMD_EDITLINE_CHANGED = 100
+		SCMD_EDITLINE_CHANGED = 100,
+		SCMD_EDITLINE_DELETED,
+		SCMD_EDITLINE_INSERTED
 	};
 
 	class clValidator: public iIntrusiveCounter
@@ -234,13 +236,20 @@ namespace wal
 		CaptureSD captureSD;
 
 		void DrawCursor( GC& gc );
-		bool CheckCursorPos(); //true -если нужна перерисовка
+		bool CheckCursorPos(); //true - if redrawing is needed
 		void ClipboardCopy();
 		void ClipboardPaste();
 		void ClipboardCut();
 		int GetCharPos( cpoint p );
 	protected:
 		virtual void Changed() { if ( Parent() ) { Parent()->Command( CMD_EDITLINE_INFO, SCMD_EDITLINE_CHANGED, this, 0 ); } }
+		virtual void SendCommand(const int cmd)
+		{
+			if ( Parent() )
+			{
+				Parent()->Command( CMD_EDITLINE_INFO, cmd, this, 0 );
+			}
+		}
 	public:
 		EditLine( int nId, Win* parent, const crect* rect, const unicode_t* txt, int chars = 10, bool frame = true, unsigned flags = 0 );
 		void SetAcceptAltKeys() { doAcceptAltKeys = true; }
@@ -257,6 +266,7 @@ namespace wal
 		void Insert( const unicode_t* txt );
 		bool IsEmpty() const;
 		int GetCursorPos() { return text.Cursor(); }
+		int GetMarkerPos() { return text.Marker(); }
 		void SetCursorPos( int c, bool mark = false ) { text.SetCursor( c, mark ); }
 		void SetReplaceMode( bool ReplaceMode ) { m_ReplaceMode = ReplaceMode; }
 		std::vector<unicode_t> GetText() const;
@@ -684,6 +694,7 @@ namespace wal
 		void InsertText( unicode_t t );
 		void InsertText( const unicode_t* txt );
 		int GetCursorPos() { return _edit.GetCursorPos(); }
+		int GetMarkerPos() { return _edit.GetMarkerPos(); }
 		void SetCursorPos( int c, bool mark = false ) { _edit.SetCursorPos( c, mark ); }
 
 

--- a/src/swl/swl_winbase.h
+++ b/src/swl/swl_winbase.h
@@ -706,12 +706,13 @@ namespace wal
 		const unicode_t* ItemText( int n );
 
 		void* ItemData( int n );
-		void MoveCurrent( int n );
+		void MoveCurrent( int n, bool notify = true );
 		bool IsBoxOpened() { return _box.ptr() != 0; }
 		void CloseBox();
 		
         virtual bool OnOpenBox();
 		virtual void OnCloseBox();
+		virtual void OnItemChanged( int ItemIndex );
 	};
 
 //ToolTip is global, setting new one is replaceing previous

--- a/src/swl/swl_winbase.h
+++ b/src/swl/swl_winbase.h
@@ -690,7 +690,9 @@ namespace wal
 		void Append( const char* text, void* data = 0 );
 
 		std::vector<unicode_t> GetText() const;
+		std::string GetTextStr() const;
 		void SetText( const unicode_t* txt, bool mark = false );
+		void SetText( const std::string& utf8txt, bool mark = false );
 		void InsertText( unicode_t t );
 		void InsertText( const unicode_t* txt );
 		int GetCursorPos() { return _edit.GetCursorPos(); }

--- a/src/swl/swl_winbase.h
+++ b/src/swl/swl_winbase.h
@@ -6,7 +6,6 @@
 
 namespace wal
 {
-
 	extern int uiClassButton;
 	extern int uiClassEditLine;
 	extern int uiClassMenuBar;
@@ -638,19 +637,22 @@ namespace wal
 			FRAME3D  = 4,
 			NOFOCUSFRAME = 8
 		};
-	private:
+	
+    private:
 		unsigned _flags;
 		CaptureSD captureSD;
 		Layout _lo;
-		struct Node
+		
+        struct Node
 		{
 			std::vector<unicode_t> text;
 			void* data;
 		};
-		EditLine _edit;
+		
+        EditLine _edit;
 		crect _buttonRect;
 		ccollect<Node, 0x100> _list;
-		clPtr<TextList> _box;
+        clPtr<TextList> _box;
 //		int _cols;
 		int _rows;
 		int _current;
@@ -663,14 +665,17 @@ namespace wal
 
 	public:
 		ComboBox( int nId, Win* parent, int cols, int rows, unsigned flags = 0,  crect* rect = 0 );
-		virtual void Paint( GC& gc, const crect& paintRect );
+        virtual ~ComboBox() {}
+		
+        virtual void Paint( GC& gc, const crect& paintRect );
 		virtual bool EventMouse( cevent_mouse* pEvent );
-		virtual bool EventKey( cevent_key* pEvent );
+        virtual bool EventKey( cevent_key* pEvent );
 		virtual bool EventFocus( bool recv );
 		virtual bool Command( int id, int subId, Win* win, void* d );
 		virtual void OnChangeStyles();
 		virtual int UiGetClassId();
-		void Clear();
+		
+        void Clear();
 		void Append( const unicode_t* text, void* data = 0 );
 		void Append( const char* text, void* data = 0 );
 
@@ -690,16 +695,15 @@ namespace wal
 		void MoveCurrent( int n );
 		bool IsBoxOpened() { return _box.ptr() != 0; }
 		void CloseBox();
-		virtual bool OnOpenBox();
+		
+        virtual bool OnOpenBox();
 		virtual void OnCloseBox();
-
-		virtual ~ComboBox();
 	};
 
-//ToolTip один на все приложение, поэтому установка нового, удаляет предыдущий
+//ToolTip is global, setting new one is replaceing previous
 	void ToolTipShow( Win* w, int x, int y, const unicode_t* s );
 	void ToolTipShow( int x, int y, const char* s );
 	void ToolTipHide();
 
 
-}; // namespace wal
+}// namespace wal

--- a/src/wal/wal.cpp
+++ b/src/wal/wal.cpp
@@ -180,21 +180,30 @@ namespace wal
 		return ( *StartPos ) ? new_unicode_str( StartPos ) : std::vector<unicode_t>();
 	}
 
-	bool unicode_starts_with_and_not_equal( const unicode_t* Str, const unicode_t* SubStr )
+	bool unicode_starts_with_and_not_equal( const unicode_t* Str, const unicode_t* SubStr, bool IgnoreCase )
 	{
-		if ( !Str || !SubStr ) { return false; }
+		if ( !Str || !SubStr )
+		{
+			return false;
+		}
 
-		const unicode_t* S = Str;
-		const unicode_t* SS = SubStr;
-
-		while ( *SS != 0 ) if ( *S++ != *SS++ )
+		while ( *SubStr != 0 )
+		{
+			unicode_t S = *Str++;
+			unicode_t SS = *SubStr++;
+			if ( IgnoreCase )
+			{
+				S = UnicodeLC( S );
+				SS = UnicodeLC( SS );
+			}
+			
+			if ( S != SS )
 			{
 				return false;
 			}
+		}
 
-		if ( *SS == 0 && *S == 0 ) { return false; }
-
-		return true;
+		return !( *Str == 0 && *SubStr == 0 );
 	}
 
 	bool utf8_starts_with_and_not_equal( const char* Str, const char* SubStr )

--- a/src/wal/wal.h
+++ b/src/wal/wal.h
@@ -42,7 +42,7 @@ namespace wal
 	bool unicode_is_equal( const unicode_t* Str, const unicode_t* SubStr );
 	int unicode_strcmp(const unicode_t* s1, const unicode_t* s2);
 	int unicode_stricmp(const unicode_t* s1, const unicode_t* s2);
-	bool unicode_starts_with_and_not_equal( const unicode_t* Str, const unicode_t* SubStr );
+	bool unicode_starts_with_and_not_equal( const unicode_t* Str, const unicode_t* SubStr, bool IgnoreCase = false );
 	bool utf8_starts_with_and_not_equal( const char* Str, const char* SubStr );
 	std::vector<unicode_t> unicode_get_last_word( const unicode_t* Str, const unicode_t** LastWordStart, bool UsePathSeparator );
 

--- a/src/wcm-config.cpp
+++ b/src/wcm-config.cpp
@@ -256,14 +256,6 @@ void SysTextFileOut::Write( char* buf, int size ) {  f.Write( buf, size ); }
 static FSPath configDirPath( CS_UTF8, "???" );
 
 
-void IniHashLoad( IniHash& iniHash, const char* sectName )
-{
-	FSPath path = configDirPath;
-	path.Push( CS_UTF8, carray_cat<char>( sectName, ".cfg" ).data() );
-
-	LoadIniHash( iniHash, (sys_char_t*) path.GetString( sys_charset_id ) );
-}
-
 void LoadIniHash( IniHash& iniHash, const sys_char_t* fileName )
 {
 	SysTextFileIn in;
@@ -347,6 +339,14 @@ void LoadIniHash( IniHash& iniHash, const sys_char_t* fileName )
 	in.Close();
 }
 
+void IniHashLoad( IniHash& iniHash, const char* sectName )
+{
+	FSPath path = configDirPath;
+	path.Push( CS_UTF8, carray_cat<char>( sectName, ".cfg" ).data() );
+	
+	LoadIniHash( iniHash, (sys_char_t*) path.GetString( sys_charset_id ) );
+}
+
 inline bool strless( const char* a, const char* b )
 {
 	const char* s1 = a;
@@ -355,14 +355,6 @@ inline bool strless( const char* a, const char* b )
 	while ( *s1 && *s1 == *s2 ) { s1++; s2++; };
 
 	return *s1 <= *s2;
-}
-
-void IniHashSave( IniHash& iniHash, const char* sectName )
-{
-	FSPath path = configDirPath;
-	path.Push( CS_UTF8, carray_cat<char>( sectName, ".cfg" ).data() );
-	
-	SaveIniHash( iniHash, (sys_char_t*) path.GetString( sys_charset_id ) );
 }
 
 void SaveIniHash( IniHash& iniHash, const sys_char_t* fileName )
@@ -404,6 +396,14 @@ void SaveIniHash( IniHash& iniHash, const sys_char_t* fileName )
 
 	out.Flush();
 	out.Close();
+}
+
+void IniHashSave( IniHash& iniHash, const char* sectName )
+{
+	FSPath path = configDirPath;
+	path.Push( CS_UTF8, carray_cat<char>( sectName, ".cfg" ).data() );
+	
+	SaveIniHash( iniHash, (sys_char_t*) path.GetString( sys_charset_id ) );
 }
 
 

--- a/src/wcm-config.cpp
+++ b/src/wcm-config.cpp
@@ -17,6 +17,7 @@
 #include "ltext.h"
 #include "globals.h"
 #include "folder-history.h"
+#include "nchistory.h"
 
 #ifdef _WIN32
 #  include "w32util.h"
@@ -1401,7 +1402,8 @@ void clWcmConfig::Load( NCWin* nc )
 
 	LoadEditorPositions();
 	LoadViewerPositions();
-    LoadFoldersHistory();
+	LoadFoldersHistory();
+	LoadFieldsHistory();
 }
 
 void SaveEditorPositions()
@@ -1516,7 +1518,8 @@ void clWcmConfig::Save( NCWin* nc )
 
 	SaveEditorPositions();
 	SaveViewerPositions();
-    SaveFoldersHistory();
+	SaveFoldersHistory();
+	SaveFieldsHistory();
 }
 
 

--- a/src/wcm-config.h
+++ b/src/wcm-config.h
@@ -12,6 +12,51 @@
 
 class NCWin;
 
+
+class IniHash
+{
+private:
+	cstrhash< cstrhash< std::string > > hash;
+	std::string* Find( const char* section, const char* var );
+	std::string* Create( const char* section, const char* var );
+	void Delete( const char* section, const char* var );
+
+public:
+	IniHash() { }
+	~IniHash() { }
+
+	void SetStrValue( const char* section, const char* var, const char* value );
+	void SetIntValue( const char* section, const char* var, int value );
+	void SetBoolValue( const char* section, const char* var, bool value );
+	const char* GetStrValue( const char* section, const char* var, const char* def );
+	int GetIntValue( const char* section, const char* var, int def );
+	bool GetBoolValue( const char* section, const char* var, bool def );
+	
+	void Clear()
+	{
+		hash.clear();
+	}
+
+	int Size() const
+	{
+		return hash.count();
+	}
+
+	std::vector<const char*> Keys()
+	{
+		 return hash.keys();
+	}
+
+	cstrhash<std::string>* Exist( const char* key)
+	{
+		 return hash.exist( key );
+	}
+};
+
+void IniHashLoad( IniHash& iniHash, const char* sectName );
+void IniHashSave( IniHash& iniHash, const char* sectName );
+
+
 enum ePanelSpacesMode
 {
 	ePanelSpacesMode_None = 0,

--- a/wcm_2013.vcxproj
+++ b/wcm_2013.vcxproj
@@ -265,6 +265,7 @@
     <ClCompile Include="src/wal\wal_sys_api.cpp" />
     <ClCompile Include="src/wal\wal_tmpls.cpp" />
     <ClCompile Include="src/wcm-config.cpp" />
+    <ClCompile Include="src\nceditline.cpp" />
     <ClCompile Include="src\urlparser\LUrlParser.cpp" />
     <ClCompile Include="src\folder-history.cpp" />
     <ClCompile Include="src\path-list.cpp" />
@@ -339,6 +340,7 @@
     <ClInclude Include="src/wal/wal_sys_api.h" />
     <ClInclude Include="src/wal/wal_tmpls.h" />
     <ClInclude Include="src/wcm-config.h" />
+    <ClInclude Include="src\nceditline.h" />
     <ClInclude Include="src/urlparser/LUrlParser.h" />
     <ClInclude Include="src/folder-history.h" />
     <ClInclude Include="src/path-list.h" />

--- a/wcm_2013.vcxproj.filters
+++ b/wcm_2013.vcxproj.filters
@@ -80,6 +80,7 @@
     <ClCompile Include="src\folder-history.cpp" />
     <ClCompile Include="src\folder-shortcuts.cpp" />
     <ClCompile Include="src\path-list.cpp" />
+    <ClCompile Include="src\nceditline.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src/charsetdlg.h" />
@@ -153,6 +154,7 @@
     <ClInclude Include="src\folder-history.h" />
     <ClInclude Include="src\folder-shortcuts.h" />
     <ClInclude Include="src\path-list.h" />
+    <ClInclude Include="src\nceditline.h" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="src/wcm.rc" />

--- a/wcm_codeblocks.cbp
+++ b/wcm_codeblocks.cbp
@@ -213,7 +213,9 @@
 		<Unit filename="src/filesearch.cpp" />
 		<Unit filename="src/filesearch.h" />
 		<Unit filename="src/folder-history.cpp" />
+		<Unit filename="src/nceditline.cpp" />
 		<Unit filename="src/folder-history.h" />
+		<Unit filename="src/nceditline.h" />
 		<Unit filename="src/folder-shortcuts.cpp" />
 		<Unit filename="src/folder-shortcuts.h" />
 		<Unit filename="src/fontdlg.cpp">

--- a/wcm_osx.pro
+++ b/wcm_osx.pro
@@ -62,6 +62,7 @@ SOURCES += src/nc.cpp \
     src/path-list.cpp \
     src/folder-shortcuts.cpp \
     src/folder-history.cpp \
+    src/nceditline.cpp \
     src/smblogon.cpp \
     src/strconfig.cpp \
     src/strmasks.cpp \
@@ -138,6 +139,7 @@ HEADERS += \
     src/path-list.h \
     src/folder-shortcuts.h \
     src/folder-history.h \
+    src/nceditline.h \
     src/smblogon.h \
     src/strconfig.h \
     src/string-util.h \


### PR DESCRIPTION
In this PR auto complete and history for edit fields (Issue #80) was implemented:
* Auto complete works exactly the same as in Far;
* Auto complete can be enabled/disabled through System option: Enable autocomplete;
* History is saved on exit:
  * Linux/OSX: in the FieldsHistory.cfg ini-file;
  * Windows: under FieldsHistory registry key;