### PR TITLE
Fixed #420 cursor is invisible for long time in edit lines

### DIFF
--- a/src/swl/swl_combobox.cpp
+++ b/src/swl/swl_combobox.cpp
@@ -230,12 +230,12 @@ namespace wal
 	{
 		_edit.EventFocus( recv );
 
-		if ( !recv && _box.ptr() )
+		if ( !recv && IsBoxOpened() )
 		{
 			CloseBox();
 		}
 
-		Invalidate();
+		//Invalidate();
 		return true;
 	}
 
@@ -293,12 +293,17 @@ namespace wal
 				break;
 					
 			default:
+				if ( _edit.EventKey( pEvent ) )
+				{
+					return true;
+				}
+
 				if ( IsBoxOpened() && _box->EventKey( pEvent ) )
 				{
 					return true;
 				}
 				
-				return _edit.EventKey( pEvent );
+				break;
 			}
 		}
 
@@ -474,8 +479,7 @@ namespace wal
 	{
 		crect cr = ClientRect();
 		unsigned bgColor = UiGetColor( uiBackground, 0, 0, 0xD8E9EC );
-//	unsigned btnColor = UiGetColor(uiButtonColor, 0, 0, 0xD8E9EC);
-
+		
 		gc.SetFillColor( bgColor );
 
 		unsigned frameColor = UiGetColor( uiFrameColor, 0, 0, 0xFFFFFF );
@@ -495,12 +499,6 @@ namespace wal
 				DrawBorder( gc, cr, frameColor );
 				cr.Dec();
 			}
-
-			/*
-			      Draw3DButtonW2(gc, cr, bgColor, false);
-			      cr.Dec();
-			      cr.Dec();
-			*/
 		}
 
 		DrawBorder( gc, cr, InFocus() && ( _flags & NOFOCUSFRAME ) == 0 ? 

--- a/src/swl/swl_combobox.cpp
+++ b/src/swl/swl_combobox.cpp
@@ -454,9 +454,16 @@ namespace wal
 					CloseBox();
 				}
 			}
+
+			return true;
 		}
 
-		return true;
+		if ( InFocus() && _edit.EventMouse( pEvent ) )
+		{
+			return true;
+		}
+
+		return Win::EventMouse( pEvent );
 	}
 
 

--- a/src/swl/swl_combobox.cpp
+++ b/src/swl/swl_combobox.cpp
@@ -77,18 +77,17 @@ namespace wal
 		   _flags( flags ),
 		   _lo( 3, 4 ),
 		   _edit( 0, this, 0, 0, cols, false, EditLine::USEPARENTFOCUS | ( ( flags& READONLY ) ? EditLine::READONLY : 0 ) ),
-//		   _cols( cols > 0 ? cols : 10 ),
 		   _rows( rows > 0 ? rows : 0 )
 	{
 		_lo.AddWin( &_edit, 1, 1 );
-		_edit.SetClickFocusFlag( false );
 		_edit.SetTabFocusFlag( false );
 		_edit.SetShowSpaces( false );
 		_edit.Enable();
 		_edit.Show( SHOW_INACTIVE );
 		_lo.AddRect( &_buttonRect, 1, 2 );
 		_lo.ColSet( 2, CB_BUTTONWIDTH );
-		int fw = ( _flags & FRAME3D ) != 0 ? 3 : ( ( _flags & NOFOCUSFRAME ) ? 0 : 1 );
+		
+		const int fw = ( _flags & FRAME3D ) != 0 ? 3 : ( ( _flags & NOFOCUSFRAME ) ? 0 : 1 );
 		_lo.ColSet( 0, fw );
 		_lo.ColSet( 3, fw );
 		_lo.LineSet( 0, fw );
@@ -103,7 +102,6 @@ namespace wal
 			_box->Clear();
 		}
 
-		//CloseBox();
 		_list.clear();
 
 		if ( _current >= 0 )
@@ -119,10 +117,10 @@ namespace wal
 
 	void ComboBox::Append( const unicode_t* text, void* data )
 	{
-		//CloseBox();
 		Node node;
 		node.text = new_unicode_str( text );
 		node.data = data;
+		
 		_list.append( node );
 	}
 
@@ -139,7 +137,6 @@ namespace wal
 
 	std::vector<unicode_t> ComboBox::GetText() const
 	{
-		//static unicode_t empty = 0;
 		return _edit.GetText();
 	}
 
@@ -158,7 +155,6 @@ namespace wal
 		}
 
 		_edit.SetText( txt, mark );
-		//MoveCurrent( -1, false );
 	}
 
 	void ComboBox::SetText( const std::string& utf8txt, bool mark )
@@ -235,7 +231,6 @@ namespace wal
 			CloseBox();
 		}
 
-		//Invalidate();
 		return true;
 	}
 
@@ -407,7 +402,7 @@ namespace wal
 
 	bool ComboBox::EventMouse( cevent_mouse* pEvent )
 	{
-		if ( pEvent->Type() == EV_MOUSE_PRESS && InFocus() && _buttonRect.In( pEvent->Point() ) )
+		if ( pEvent->Type() == EV_MOUSE_PRESS && _buttonRect.In( pEvent->Point() ) )
 		{
 			if ( _box.ptr() )
 			{
@@ -463,7 +458,7 @@ namespace wal
 			return true;
 		}
 
-		if ( InFocus() && _edit.EventMouse( pEvent ) )
+		if ( _edit.EventMouse( pEvent ) )
 		{
 			return true;
 		}

--- a/src/swl/swl_editline.cpp
+++ b/src/swl/swl_editline.cpp
@@ -591,8 +591,9 @@ namespace wal
 					cursorVisible = true;
 					CheckCursorPos();
 					Invalidate();
+					return true;
 				}
-
+				
 				break;
 
 			case EV_MOUSE_DOUBLE:
@@ -610,6 +611,7 @@ namespace wal
 				Invalidate();
 
 				SetCapture( &captureSD );
+				return true;
 			}
 			break;
 
@@ -620,11 +622,10 @@ namespace wal
 				}
 
 				ReleaseCapture( &captureSD );
-				break;
+				return true;
 		};
 
-		return true;
-
+		return Win::EventMouse( pEvent );
 	}
 
 	bool EditLine::EventKey( cevent_key* pEvent )

--- a/src/swl/swl_editline.cpp
+++ b/src/swl/swl_editline.cpp
@@ -481,6 +481,27 @@ namespace wal
 		return true;
 	}
 
+	bool EditLine::InFocus()
+	{
+		if ( UseParentFocus() )
+		{
+			return Parent()->InFocus();
+		}
+
+		return Win::InFocus();
+	}
+
+	void EditLine::SetFocus()
+	{
+		if ( UseParentFocus() )
+		{
+			Parent()->SetFocus();
+			return;
+		}
+
+		Win::SetFocus();
+	}
+
 	void EditLine::Paint( GC& gc, const crect& paintRect )
 	{
 		crect cr = ClientRect();

--- a/src/swl/swl_winbase.h
+++ b/src/swl/swl_winbase.h
@@ -219,6 +219,7 @@ namespace wal
 		bool _use_alt_symbols;
 		unsigned _flags;
 		bool RO() const { return ( _flags & READONLY ) != 0; }
+		bool UseParentFocus() const { return (_flags & USEPARENTFOCUS) != 0; }
 		EditBuf text;
 		int _chars;
 		bool cursorVisible;
@@ -260,6 +261,8 @@ namespace wal
 		virtual void EventTimer( int tid );
 		virtual bool EventFocus( bool recv );
 		virtual void EventSize( cevent_size* pEvent );
+		virtual bool InFocus() override;
+		virtual void SetFocus() override;
 		void Clear();
 		void SetText( const unicode_t* txt, bool mark = false );
 		void SetText( const std::string& utf8txt, bool mark = false );

--- a/src/swl/swl_wincore.h
+++ b/src/swl/swl_wincore.h
@@ -1099,7 +1099,7 @@ namespace wal
 		void Move( crect rect, bool repaint = true );
 
 		bool IsEnabled();
-		bool InFocus() { return handle == focusWinId; }
+		virtual bool InFocus() { return handle == focusWinId; }
 		bool IsVisible();
 		void Enable( bool en = true );
 		void Activate();
@@ -1108,7 +1108,7 @@ namespace wal
 		void OnTop();
 		bool IsCaptured() { return captured; }
 		void Invalidate();
-		void SetFocus();
+		virtual void SetFocus();
 
 		void SetName( const unicode_t* name );
 		void SetName( const char* utf8Name );


### PR DESCRIPTION
In PR issue #420 was fixed.

The main problem was that EditLine control doesn't properly get focus state while in ComboBox. There were other small issues with keys and mouse events not properly propagating to EditLine, also. All of them are fixed now.